### PR TITLE
feat(route): enable/disable route ID input based on mode (edit/create)

### DIFF
--- a/src/locales/lang/zh_CN/pages/apisix-route-edit.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-route-edit.ts
@@ -5,6 +5,8 @@ export default {
   submitError: '提交失败：{message}',
   step1: {
     title: '设置路由信息',
+    id: '路由id',
+    idPlaceholder: '可选的路由ID，如果不输入，将自动生成',
     subtitle: '设置路由信息',
     basic: '基本信息',
     name: '名称',

--- a/src/locales/lang/zh_CN/pages/apisix-route-edit.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-route-edit.ts
@@ -3,6 +3,8 @@ export default {
   nextStep: '下一步',
   submit: '提交',
   submitError: '提交失败：{message}',
+  routeExistsError: '路由ID已存在, 请勿重复提交',
+  unknownError: '未知原因提交失败: {message}',
   step1: {
     title: '设置路由信息',
     id: '路由id',

--- a/src/pages/apisix/route/edit/index.vue
+++ b/src/pages/apisix/route/edit/index.vue
@@ -35,6 +35,14 @@
               :placeholder="t('pages.apisixRouteEdit.step1.namePlaceholder')"
             />
           </t-form-item>
+          <t-form-item :label="t('pages.apisixRouteEdit.step1.id')" name="id">
+            <t-input
+              v-model="routeId"
+              :style="{ width: '480px' }"
+              :placeholder="t('pages.apisixRouteEdit.step1.idPlaceholder')"
+              :disabled="isUpdateMode"
+            />
+          </t-form-item>
           <t-form-item :label="t('pages.apisixRouteEdit.step1.desc')" name="desc">
             <t-input
               v-model="formData.desc"
@@ -181,6 +189,8 @@ import { FORM_RULES_1, FORM_RULES_2, FORM_RULES_3, METHOD_OPTIONS } from './cons
 let INITIAL_DATA: ApisixAdminRoutesPostRequest = {};
 
 const formData = ref<ApisixAdminRoutesPostRequest>(INITIAL_DATA);
+const routeId = ref<string>('');
+const isUpdateMode = ref(false);
 const activeStep = ref(1);
 
 const router = useRouter();
@@ -188,11 +198,14 @@ const router = useRouter();
 onActivated(async () => {
   onReset();
 
-  if (!router.currentRoute.value.query.id) {
-    return;
+  const queryId = router.currentRoute.value.query.id;
+  if (queryId) {
+    isUpdateMode.value = true;
+    routeId.value = queryId.toString();
+    fetchData(routeId.value);
+  } else {
+    isUpdateMode.value = false;
   }
-  const id = router.currentRoute.value.query.id.toString();
-  fetchData(id);
 });
 
 const dataLoading = ref(false);
@@ -223,6 +236,7 @@ const onReset = () => {
   activeStep.value = 1;
   INITIAL_DATA = {};
   formData.value = cloneDeep(INITIAL_DATA);
+  routeId.value = '';
 };
 const onReapply = () => {
   onReset();
@@ -240,7 +254,7 @@ const onSubmit = async (result: SubmitContext) => {
   dataLoading.value = true;
   let res: AxiosResponse<ApisixAdminRoutesPost201Response>;
   try {
-    if (formData.value.id) {
+    if (isUpdateMode.value) {
       res = await update();
     } else {
       res = await create();
@@ -264,7 +278,7 @@ const create = () => {
 };
 const update = () => {
   const req: RouteApiApisixAdminRoutesIdPutRequest = {
-    id: formData.value.id as string,
+    id: routeId.value as string,
     apisixAdminRoutesPostRequest: formData.value,
   };
   return RouteApi.apisixAdminRoutesIdPut(req);

--- a/src/pages/apisix/route/index.vue
+++ b/src/pages/apisix/route/index.vue
@@ -20,7 +20,7 @@
         </div>
       </t-row>
       <t-table
-        v-model:displayColumns="displayColumns"
+        v-model:display-columns="displayColumns"
         :data="data"
         :columns="COLUMNS"
         :column-controller="columnControllerConfig"
@@ -227,6 +227,7 @@ const staticColumn: string[] = ['row-select', 'op'];
 const displayColumns = ref<TableProps['displayColumns']>(
   staticColumn.concat([
     'value.name',
+    'value.id',
     'value.host',
     'value.uri',
     'value.desc',


### PR DESCRIPTION
This update introduces the following improvements to Route ID handling:

*   **Route List:** The Route ID is now displayed by default in the Route list.
*   **Create Mode:** Users can define a custom Route ID when creating a new route.
*   **Edit Mode:**  The Route ID is visible in read-only mode when editing an existing route.

Test:
**Edit mode:**
![image](https://github.com/user-attachments/assets/f2d0f13e-e431-4100-bfca-9d0199899003)
**Create Mode**
![image](https://github.com/user-attachments/assets/5bbdd448-9f0c-4e2b-a068-0416c5bcf0c6)

**Create duplicate id**
![image](https://github.com/user-attachments/assets/6bcc3c5e-637e-44fd-92b9-96401a3cfb37)

