### PR TITLE
fix(route): fix create_time and modify_time format error

### DIFF
--- a/src/pages/apisix/route/index.vue
+++ b/src/pages/apisix/route/index.vue
@@ -72,12 +72,12 @@
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
         <template #value.create_time="{ row }">
-          {{ dayjs.unix(row.value.create_time).format('L LT') }}
+          {{ dayjs.unix(row.value.create_time).format('YYYY-MM-DD HH:mm:ss') }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
         <template #value.update_time="{ row }">
-          {{ dayjs.unix(row.value.update_time).format('L LT') }}
+          {{ dayjs.unix(row.value.update_time).format('YYYY-MM-DD HH:mm:ss') }}
         </template>
 
         <template #op="slotProps: BaseTableCellParams<Item>">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e9439ebb-bffb-46ef-8fcd-28e12f3c6548)

This lead to 2 new problems:
1. Column Width Issue: The routes table displays correctly overall, but the column widths are unstable and can become squeezed or misaligned.
2. Configuration Persistence: The table configuration cannot be saved in the browser, so users must reconfigure it every time the page is opened.