### PR TITLE
refactor: table pages

### DIFF
--- a/src/locales/lang/zh_CN/pages/apisix-consumer.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-consumer.ts
@@ -1,10 +1,10 @@
 export default {
-  export: '导出TODO',
-  create: '新建',
   selectedCount: '已选 {num} 项',
   placeholder: '请输入内容搜索TODO',
   operation: '操作',
   operations: {
+    export: '导出TODO',
+    create: '新建',
     view: '查看',
     edit: '编辑',
     delete: '删除',

--- a/src/locales/lang/zh_CN/pages/apisix-globalRule.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-globalRule.ts
@@ -1,10 +1,10 @@
 export default {
-  export: '导出TODO',
-  create: '新建',
   selectedCount: '已选 {num} 项',
   placeholder: '请输入内容搜索TODO',
   operation: '操作',
   operations: {
+    export: '导出TODO',
+    create: '新建',
     view: '查看',
     edit: '编辑',
     delete: '删除',

--- a/src/locales/lang/zh_CN/pages/apisix-proto.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-proto.ts
@@ -1,10 +1,10 @@
 export default {
-  export: '导出TODO',
-  create: '新建',
   selectedCount: '已选 {num} 项',
   placeholder: '请输入内容搜索TODO',
   operation: '操作',
   operations: {
+    export: '导出TODO',
+    create: '新建',
     view: '查看',
     edit: '编辑',
     delete: '删除',

--- a/src/locales/lang/zh_CN/pages/apisix-route.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-route.ts
@@ -1,11 +1,11 @@
 export default {
-  export: '导出TODO',
-  create: '新建',
   selectedCount: '已选 {num} 项',
   placeholder: '请输入内容搜索TODO',
   viewConfirm: '确定',
   operation: '操作',
   operations: {
+    export: '导出TODO',
+    create: '新建',
     view: '查看',
     edit: '编辑',
     delete: '删除',

--- a/src/locales/lang/zh_CN/pages/apisix-secret.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-secret.ts
@@ -1,10 +1,10 @@
 export default {
-  export: '导出TODO',
-  create: '新建',
   selectedCount: '已选 {num} 项',
   placeholder: '请输入内容搜索TODO',
   operation: '操作',
   operations: {
+    export: '导出TODO',
+    create: '新建',
     view: '查看',
     edit: '编辑',
     delete: '删除',

--- a/src/locales/lang/zh_CN/pages/apisix-service.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-service.ts
@@ -1,10 +1,10 @@
 export default {
-  export: '导出TODO',
-  create: '新建',
   selectedCount: '已选 {num} 项',
   placeholder: '请输入内容搜索TODO',
   operation: '操作',
   operations: {
+    export: '导出TODO',
+    create: '新建',
     view: '查看',
     edit: '编辑',
     delete: '删除',

--- a/src/locales/lang/zh_CN/pages/apisix-ssl.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-ssl.ts
@@ -1,10 +1,10 @@
 export default {
-  export: '导出TODO',
-  create: '新建',
   selectedCount: '已选 {num} 项',
   placeholder: '请输入内容搜索TODO',
   operation: '操作',
   operations: {
+    export: '导出TODO',
+    create: '新建',
     view: '查看',
     edit: '编辑',
     delete: '删除',

--- a/src/locales/lang/zh_CN/pages/apisix-upstream.ts
+++ b/src/locales/lang/zh_CN/pages/apisix-upstream.ts
@@ -1,10 +1,10 @@
 export default {
-  export: '导出TODO',
-  create: '新建',
   selectedCount: '已选 {num} 项',
   placeholder: '请输入内容搜索TODO',
   operation: '操作',
   operations: {
+    export: '导出TODO',
+    create: '新建',
     view: '查看',
     edit: '编辑',
     delete: '删除',

--- a/src/pages/apisix/consumer/index.vue
+++ b/src/pages/apisix/consumer/index.vue
@@ -3,12 +3,12 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="opClickCreate"> {{ t('pages.apisixConsumer.create') }} </t-button>
+          <t-button @click="opClickCreate"> {{ t('pages.apisixConsumer.operations.create') }} </t-button>
           <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
-            {{ t('pages.apisixConsumer.delete') }}
+            {{ t('pages.apisixConsumer.operations.delete') }}
           </t-button>
           <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
-            {{ t('pages.apisixConsumer.export') }}</t-button
+            {{ t('pages.apisixConsumer.operations.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixConsumer.selectedCount', { num: tabSelectedRowKeys.length }) }}

--- a/src/pages/apisix/consumer/index.vue
+++ b/src/pages/apisix/consumer/index.vue
@@ -3,16 +3,19 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="handleCreate"> {{ t('pages.apisixConsumer.create') }} </t-button>
-          <t-button variant="base" theme="default" :disabled="!selectedRowKeys.length">
+          <t-button @click="opClickCreate"> {{ t('pages.apisixConsumer.create') }} </t-button>
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+            {{ t('pages.apisixConsumer.delete') }}
+          </t-button>
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
             {{ t('pages.apisixConsumer.export') }}</t-button
           >
-          <p v-if="!!selectedRowKeys.length" class="selected-count">
-            {{ t('pages.apisixConsumer.selectedCount', { num: selectedRowKeys.length }) }}
+          <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
+            {{ t('pages.apisixConsumer.selectedCount', { num: tabSelectedRowKeys.length }) }}
           </p>
         </div>
         <div class="search-input">
-          <t-input v-model="searchValue" :placeholder="t('pages.apisixConsumer.placeholder')" clearable>
+          <t-input v-model="tabSearchValue" :placeholder="t('pages.apisixConsumer.placeholder')" clearable>
             <template #suffix-icon>
               <search-icon size="16px" />
             </template>
@@ -20,24 +23,22 @@
         </div>
       </t-row>
       <t-table
-        v-model:displayColumns="displayColumns"
-        :data="data"
+        v-model:display-columns="DISPLAY_COLUMNS"
+        :data="tabData"
         :columns="COLUMNS"
-        :column-controller="columnControllerConfig"
-        :row-key="rowKey"
+        :column-controller="COLUMN_CONTROLLER"
+        :row-key="ROW_PK"
         vertical-align="top"
         :hover="true"
-        :pagination="pagination"
-        :selected-row-keys="selectedRowKeys"
-        :loading="dataLoading"
+        :pagination="tabPagination"
+        :selected-row-keys="tabSelectedRowKeys"
+        :loading="tabDataLoading"
         :header-affixed-top="headerAffixedTop"
         table-layout="auto"
-        @page-change="rehandlePageChange"
-        @change="rehandleChange"
-        @select-change="(value: string[]) => rehandleSelectChange(value)"
+        @select-change="tabSelectChange"
       >
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.labels="{ row }">
+        <template #value.labels="{ row }: BaseTableCellParams<Row>">
           <t-space size="small">
             <t-tag v-for="(value, key) in row.value.labels" :key="key" variant="light-outline">
               {{ key }}:{{ value }}
@@ -46,7 +47,7 @@
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.plugins="{ row }">
+        <template #value.plugins="{ row }: BaseTableCellParams<Row>">
           <t-space size="small">
             <t-tag v-for="(value, key) in row.value.plugins" :key="key" variant="light-outline">
               {{ key }}
@@ -55,24 +56,24 @@
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.create_time="{ row }">
+        <template #value.create_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.create_time).format('L LT') }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.update_time="{ row }">
+        <template #value.update_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.update_time).format('L LT') }}
         </template>
 
-        <template #op="slotProps: BaseTableCellParams<Item>">
+        <template #op="slotProps: BaseTableCellParams<Row>">
           <t-space>
-            <t-link theme="primary" @click="handleClickView(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickView(slotProps)">
               {{ t('pages.apisixConsumer.operations.view') }}</t-link
             >
-            <t-link theme="primary" @click="handleClickEdit(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickEdit(slotProps)">
               {{ t('pages.apisixConsumer.operations.edit') }}</t-link
             >
-            <t-link theme="danger" @click="handleClickDelete(slotProps)">
+            <t-link theme="danger" @click="tabRowOnClickDelete(slotProps)">
               {{ t('pages.apisixConsumer.operations.delete') }}</t-link
             >
           </t-space>
@@ -81,30 +82,35 @@
     </t-card>
 
     <t-dialog
-      v-model:visible="confirmVisible"
+      v-model:visible="delModalVisible"
       :header="t('pages.apisixConsumer.deleteConfirm.header')"
-      :on-cancel="onCancel"
-      @confirm="onConfirmDelete"
+      :on-cancel="delModalOnCancel"
+      @confirm="delModalOnConfirm"
     >
-      <p v-if="deleteIdx.length === 1">
+      <p v-if="toDelRowKeys.length === 1">
         {{
           t('pages.apisixConsumer.deleteConfirm.deleteOne', {
-            name: data[deleteIdx[0]]?.value?.username,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.username,
           })
         }}
       </p>
-      <p v-if="deleteIdx.length > 1">
+      <p v-if="toDelRowKeys.length > 1">
         {{
           t('pages.apisixConsumer.deleteConfirm.deleteMulti', {
-            name: data[deleteIdx[0]]?.value?.username,
-            num: deleteIdx.length,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.username,
+            num: toDelRowKeys.length,
           })
         }}
       </p>
     </t-dialog>
 
-    <t-drawer v-model:visible="drawerVisible" :header="drawerHeader" :on-confirm="onDrawerClickConfirm" size="medium">
-      <code-editor v-model:value="drawerBody" language="json" />
+    <t-drawer v-model:visible="viewDrawerVisible" :header="viewDrawerHeader" size="medium">
+      <code-editor v-model:value="viewDrawerContent" language="json" :options="{ readOnly: true }" />
+      <template #footer>
+        <t-button theme="primary" @click="viewDrawerVisible = false">
+          {{ t('pages.apisixConsumer.viewConfirm') }}
+        </t-button>
+      </template>
     </t-drawer>
   </div>
 </template>
@@ -116,246 +122,149 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { AxiosPromise } from 'axios';
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
-import { BaseTableCellParams, MessagePlugin, PrimaryTableCol, TableProps, TableRowData } from 'tdesign-vue-next';
+import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { ConsumerApi } from '@/api/apisix/admin';
-import {
-  ApisixAdminConsumersGet200ResponseListInner as Item,
-  ApisixAdminRoutesIdDelete200Response,
-} from '@/api/apisix/admin/typescript-axios';
+import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
 import CodeEditor from '@/components/code-editor/index.vue';
 import { prefix } from '@/config/global';
 import { t } from '@/locales';
 import { useSettingStore } from '@/store';
 
-const store = useSettingStore();
+import type { Row, RowPK } from './table';
+import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-const COLUMNS: PrimaryTableCol<TableRowData>[] = [
-  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
-  {
-    title: t('pages.apisixConsumer.root.key'),
-    colKey: 'key',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixConsumer.root.createdIndex'),
-    colKey: 'createdIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixConsumer.root.modifiedIndex'),
-    colKey: 'modifiedIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixConsumer.value.username'),
-    colKey: 'value.username',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixConsumer.value.labels'),
-    colKey: 'value.labels',
-  },
-  {
-    title: t('pages.apisixConsumer.value.plugins'),
-    colKey: 'value.plugins',
-  },
-  {
-    title: t('pages.apisixConsumer.value.desc'),
-    colKey: 'value.desc',
-  },
-  {
-    title: t('pages.apisixConsumer.value.group_id'),
-    colKey: 'value.group_id',
-  },
-  {
-    title: t('pages.apisixConsumer.value.create_time'),
-    colKey: 'value.create_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixConsumer.value.update_time'),
-    colKey: 'value.update_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixConsumer.operation'),
-    align: 'left',
-    fixed: 'right',
-    colKey: 'op',
-    width: 160,
-  },
-];
-const staticColumn: string[] = ['row-select', 'op'];
-const displayColumns = ref<TableProps['displayColumns']>(
-  staticColumn.concat(['value.username', 'value.labels', 'value.plugins', 'value.desc', 'value.group_id']),
-);
-const columnControllerConfig = computed<TableProps['columnController']>(() => ({
-  // 列配置按钮位置
-  placement: 'top-right',
-  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
-  fields: undefined,
-  // 弹框组件属性透传
-  dialogProps: {
-    preventScrollThrough: true,
-  },
-  // 列配置按钮组件属性透传
-  buttonProps: undefined,
-  // 数据字段分组显示
-  groupColumns: [
-    {
-      label: 'root',
-      value: 'root',
-      columns: ['key', 'createdIndex', 'modifiedIndex'],
-    },
-    {
-      label: 'value',
-      value: 'value',
-      columns: [
-        'value.username',
-        'value.labels',
-        'value.plugins',
-        'value.desc',
-        'value.group_id',
-        'value.create_time',
-        'value.update_time',
-      ],
-    },
-  ],
-}));
+onMounted(() => {
+  tabRefresh();
+});
 
-const data = ref<Item[]>([]);
-const pagination = ref({
+const router = useRouter();
+
+// #region Table
+
+const tabPagination = ref({
   defaultPageSize: 20,
   total: 100,
   defaultCurrent: 1,
 });
+const tabSearchValue = ref('');
+const tabData = ref<Row[]>([]);
+const tabDataLoading = ref(false);
+const tabSelectedRowKeys = ref<RowPK[]>([]);
 
-const searchValue = ref('');
+const tabSelectChange: TableProps['onSelectChange'] = (selectedRowKey, options) => {
+  tabSelectedRowKeys.value = selectedRowKey.slice() as RowPK[];
+};
 
-const dataLoading = ref(false);
-const fetchData = async () => {
-  dataLoading.value = true;
+const tabRefresh = async () => {
+  tabDataLoading.value = true;
   try {
-    const res = await ConsumerApi.apisixAdminConsumersGet({
-      params: {
-        page: pagination.value.defaultCurrent,
-        page_size: pagination.value.defaultPageSize,
-      },
-    });
-    let { list } = res.data;
-    // fix: when apisix returns list as {}
-    if (!(list instanceof Array)) {
-      list = [];
-    }
-
-    data.value = list;
-    pagination.value = {
-      ...pagination.value,
-      total: list.length,
+    const resData = await fetchData(undefined, tabPagination.value);
+    tabData.value = resData.list;
+    tabPagination.value = {
+      ...tabPagination.value,
+      total: resData.total,
     };
   } catch (e) {
     console.error(e);
   }
-  dataLoading.value = false;
+  tabDataLoading.value = false;
 };
 
-const deleteIdx = ref<number[]>([]);
+// #endregion Table
 
-onMounted(() => {
-  fetchData();
-});
+// #region Delete
 
-const confirmVisible = ref(false);
+const toDelRowKeys = ref<RowPK[]>([]);
+const delModalVisible = ref(false);
 
-const selectedRowKeys = ref<string[]>([]);
-
-const router = useRouter();
-
-const resetIdx = () => {
-  deleteIdx.value = [];
+const delReset = () => {
+  toDelRowKeys.value = [];
 };
 
-const onConfirmDelete = async () => {
-  // 真实业务请发起请求
-  const ps: AxiosPromise<ApisixAdminRoutesIdDelete200Response>[] = [];
-  deleteIdx.value.forEach((rowIndex) => {
-    const { username } = data.value[rowIndex].value;
-    const p = ConsumerApi.apisixAdminConsumersUsernameDelete({
-      username,
-      force: 'false',
-    });
+const delModalOnCancel = () => {
+  delReset();
+};
+
+const delModalOnConfirm = async () => {
+  const ps: Promise<ApisixAdminRoutesIdDelete200Response>[] = [];
+  toDelRowKeys.value.forEach((rowKey) => {
+    const row = tabData.value.find((e) => e.key === rowKey);
+    const p = deleteRow(row);
     ps.push(p);
   });
-  const resArr = await Promise.all(ps);
+  const resDataArr = await Promise.all(ps); // TODO: 报告成功和失败情况
 
-  const successResArr = resArr.filter((res) => {
-    return res.status === 200 && res.data.deleted;
-  });
+  const successResDataArr = resDataArr.filter((d) => d.deleted);
 
-  resetIdx();
-  confirmVisible.value = false;
-  MessagePlugin.success(t('pages.apisixConsumer.deleteMessage.success', { num: successResArr.length }));
+  delReset();
+  delModalVisible.value = false;
+  MessagePlugin.success(t('pages.apisixConsumer.deleteMessage.success', { num: successResDataArr.length }));
 
-  await fetchData();
+  await tabRefresh();
 };
 
-const onCancel = () => {
-  resetIdx();
+const opOnClickDelete = () => {
+  toDelRowKeys.value = tabSelectedRowKeys.value.slice();
+  delModalVisible.value = true;
 };
 
-const rowKey = 'key';
+const tabRowOnClickDelete = (slotProps: BaseTableCellParams<Row>) => {
+  toDelRowKeys.value = [slotProps.row.key];
+  delModalVisible.value = true;
+};
 
-const rehandleSelectChange = (val: string[]) => {
-  selectedRowKeys.value = val;
-};
-const rehandlePageChange = (curr: unknown, pageInfo: unknown) => {
-  console.log('分页变化', curr, pageInfo);
-};
-const rehandleChange = (changeParams: unknown, triggerAndData: unknown) => {
-  console.log('统一Change', changeParams, triggerAndData);
-};
-const handleClickView = (slotProps: BaseTableCellParams<Item>) => {
-  drawerHeader.value = slotProps.row.value.username;
-  drawerBody.value = JSON.stringify(slotProps.row.value, null, 2);
-  drawerVisible.value = true;
-};
-const handleClickEdit = (slotProps: BaseTableCellParams<Item>) => {
-  router.push(`/apisix/consumer/edit?username=${slotProps.row.value.username}`);
-};
-const handleCreate = () => {
+// #endregion Delete
+
+// #region Create
+
+const opClickCreate = () => {
   router.push('/apisix/consumer/edit');
 };
-const handleClickDelete = (slotProps: BaseTableCellParams<Item>) => {
-  deleteIdx.value = [slotProps.rowIndex];
-  confirmVisible.value = true;
+
+// #endregion Create
+
+// #region Edit
+
+const tabRowOnClickEdit = (slotProps: BaseTableCellParams<Row>) => {
+  router.push(`/apisix/consumer/edit?username=${slotProps.row.value.username}`);
 };
 
+// #endregion Edit
+
+// #region Export
+
+const opClickExport = () => {
+  // TODO
+};
+
+// #endregion Export
+
+// #region View
+
+const viewDrawerVisible = ref(false);
+const viewDrawerHeader = ref('');
+const viewDrawerContent = ref('');
+
+const tabRowOnClickView = (slotProps: BaseTableCellParams<Row>) => {
+  viewDrawerHeader.value = slotProps.row.value.username;
+  viewDrawerContent.value = JSON.stringify(slotProps.row.value, null, 2);
+  viewDrawerVisible.value = true;
+};
+
+// #endregion View
+
+const settingStore = useSettingStore();
 const headerAffixedTop = computed(
   () =>
     ({
-      offsetTop: store.isUseTabsRouter ? 48 : 0,
+      offsetTop: settingStore.isUseTabsRouter ? 48 : 0,
       container: `.${prefix}-layout`,
     }) as any,
 );
-
-const drawerVisible = ref(false);
-const drawerHeader = ref('');
-const drawerBody = ref('');
-
-const onDrawerClickConfirm = () => {
-  MessagePlugin.info('数据保存中...', 1000);
-  const timer = setTimeout(() => {
-    clearTimeout(timer);
-    drawerVisible.value = false;
-    MessagePlugin.info('数据保存成功!');
-  }, 1000);
-};
 </script>
 
 <style lang="less" scoped>

--- a/src/pages/apisix/consumer/index.vue
+++ b/src/pages/apisix/consumer/index.vue
@@ -4,10 +4,10 @@
       <t-row justify="space-between">
         <div class="left-operation-container">
           <t-button @click="opClickCreate"> {{ t('pages.apisixConsumer.create') }} </t-button>
-          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
             {{ t('pages.apisixConsumer.delete') }}
           </t-button>
-          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
             {{ t('pages.apisixConsumer.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">

--- a/src/pages/apisix/consumer/index.vue
+++ b/src/pages/apisix/consumer/index.vue
@@ -125,7 +125,7 @@ export default {
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onActivated, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
@@ -137,7 +137,7 @@ import { useSettingStore } from '@/store';
 import type { Row, RowPK } from './table';
 import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-onMounted(() => {
+onActivated(() => {
   tabRefresh();
 });
 

--- a/src/pages/apisix/consumer/table.ts
+++ b/src/pages/apisix/consumer/table.ts
@@ -1,0 +1,177 @@
+import { Mutable } from '@vueuse/core';
+import { PaginationProps, TableProps } from 'tdesign-vue-next';
+import { ref } from 'vue';
+
+import { ConsumerApi } from '@/api/apisix/admin';
+import { ApisixAdminConsumersGet200ResponseListInner } from '@/api/apisix/admin/typescript-axios';
+import { t } from '@/locales';
+
+// #region Table Columns
+
+/**
+ * 表格行的数据类型
+ */
+export type Row = ApisixAdminConsumersGet200ResponseListInner;
+/**
+ * 表格行的主键键名
+ */
+export const ROW_PK: keyof Row = 'key';
+/**
+ * 表格行的主键类型
+ */
+export type RowPK = Row[typeof ROW_PK];
+
+export type Column = TableProps['columns'] & {
+  defaultHidden?: boolean;
+  canModifyHidden?: boolean;
+};
+
+export const COLUMNS: TableProps['columns'] = [
+  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
+  {
+    title: t('pages.apisixConsumer.root.key'),
+    colKey: 'key',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixConsumer.root.createdIndex'),
+    colKey: 'createdIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixConsumer.root.modifiedIndex'),
+    colKey: 'modifiedIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixConsumer.value.username'),
+    colKey: 'value.username',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixConsumer.value.labels'),
+    colKey: 'value.labels',
+  },
+  {
+    title: t('pages.apisixConsumer.value.plugins'),
+    colKey: 'value.plugins',
+  },
+  {
+    title: t('pages.apisixConsumer.value.desc'),
+    colKey: 'value.desc',
+  },
+  {
+    title: t('pages.apisixConsumer.value.group_id'),
+    colKey: 'value.group_id',
+  },
+  {
+    title: t('pages.apisixConsumer.value.create_time'),
+    colKey: 'value.create_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixConsumer.value.update_time'),
+    colKey: 'value.update_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixConsumer.operation'),
+    align: 'left',
+    fixed: 'right',
+    colKey: 'op',
+    width: 160,
+  },
+];
+
+/**
+ * 固定展示列
+ */
+const FIXED_DISPLAY_COLUMNS: string[] = ['row-select', 'op'];
+
+/**
+ * 展示列
+ */
+export const DISPLAY_COLUMNS = ref<TableProps['displayColumns']>([
+  ...FIXED_DISPLAY_COLUMNS,
+  'value.username',
+  'value.labels',
+  'value.plugins',
+  'value.desc',
+  'value.group_id',
+]);
+
+export const COLUMN_CONTROLLER = ref<TableProps['columnController']>({
+  // 列配置按钮位置
+  placement: 'top-right',
+  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
+  fields: undefined,
+  // 弹框组件属性透传
+  dialogProps: {
+    preventScrollThrough: true,
+  },
+  // 列配置按钮组件属性透传
+  buttonProps: undefined,
+  // 数据字段分组显示
+  groupColumns: [
+    {
+      label: 'root',
+      value: 'root',
+      columns: ['key', 'createdIndex', 'modifiedIndex'],
+    },
+    {
+      label: 'value',
+      value: 'value',
+      columns: [
+        'value.username',
+        'value.labels',
+        'value.plugins',
+        'value.desc',
+        'value.group_id',
+        'value.create_time',
+        'value.update_time',
+      ],
+    },
+  ],
+});
+
+// #endregion Table Columns
+
+// #region Table Data Action
+
+// 筛选器表单的数据类型
+export type SearchFormData = Mutable<void>; // TODO
+
+export const fetchData = async (searchFormData: SearchFormData, paginationInfo: PaginationProps) => {
+  try {
+    const res = await ConsumerApi.apisixAdminConsumersGet({
+      params: {
+        page: paginationInfo.current,
+        page_size: paginationInfo.pageSize,
+      },
+    });
+
+    // fix: when empty, apisix returns list as {}
+    if (res.data.total === 0 && !(res.data.list instanceof Array)) {
+      res.data.list = [];
+    }
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch data:', error);
+    throw error;
+  }
+};
+
+export const deleteRow = async (row: Row) => {
+  try {
+    const res = await ConsumerApi.apisixAdminConsumersUsernameDelete({
+      username: row.value.username,
+      force: 'false',
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to delete row:', error);
+    throw error;
+  }
+};
+
+// #endregion Table Data Action

--- a/src/pages/apisix/global_rule/index.vue
+++ b/src/pages/apisix/global_rule/index.vue
@@ -3,12 +3,12 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="opClickCreate"> {{ t('pages.apisixGlobalRule.create') }} </t-button>
+          <t-button @click="opClickCreate"> {{ t('pages.apisixGlobalRule.operations.create') }} </t-button>
           <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
-            {{ t('pages.apisixGlobalRule.delete') }}
+            {{ t('pages.apisixGlobalRule.operations.delete') }}
           </t-button>
           <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
-            {{ t('pages.apisixGlobalRule.export') }}</t-button
+            {{ t('pages.apisixGlobalRule.operations.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixGlobalRule.selectedCount', { num: tabSelectedRowKeys.length }) }}

--- a/src/pages/apisix/global_rule/index.vue
+++ b/src/pages/apisix/global_rule/index.vue
@@ -3,16 +3,19 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="handleCreate"> {{ t('pages.apisixGlobalRule.create') }} </t-button>
-          <t-button variant="base" theme="default" :disabled="!selectedRowKeys.length">
+          <t-button @click="opClickCreate"> {{ t('pages.apisixGlobalRule.create') }} </t-button>
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+            {{ t('pages.apisixGlobalRule.delete') }}
+          </t-button>
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
             {{ t('pages.apisixGlobalRule.export') }}</t-button
           >
-          <p v-if="!!selectedRowKeys.length" class="selected-count">
-            {{ t('pages.apisixGlobalRule.selectedCount', { num: selectedRowKeys.length }) }}
+          <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
+            {{ t('pages.apisixGlobalRule.selectedCount', { num: tabSelectedRowKeys.length }) }}
           </p>
         </div>
         <div class="search-input">
-          <t-input v-model="searchValue" :placeholder="t('pages.apisixGlobalRule.placeholder')" clearable>
+          <t-input v-model="tabSearchValue" :placeholder="t('pages.apisixGlobalRule.placeholder')" clearable>
             <template #suffix-icon>
               <search-icon size="16px" />
             </template>
@@ -20,24 +23,22 @@
         </div>
       </t-row>
       <t-table
-        v-model:displayColumns="displayColumns"
-        :data="data"
+        v-model:display-columns="DISPLAY_COLUMNS"
+        :data="tabData"
         :columns="COLUMNS"
-        :column-controller="columnControllerConfig"
-        :row-key="rowKey"
+        :column-controller="COLUMN_CONTROLLER"
+        :row-key="ROW_PK"
         vertical-align="top"
         :hover="true"
-        :pagination="pagination"
-        :selected-row-keys="selectedRowKeys"
-        :loading="dataLoading"
+        :pagination="tabPagination"
+        :selected-row-keys="tabSelectedRowKeys"
+        :loading="tabDataLoading"
         :header-affixed-top="headerAffixedTop"
         table-layout="auto"
-        @page-change="rehandlePageChange"
-        @change="rehandleChange"
-        @select-change="(value: string[]) => rehandleSelectChange(value)"
+        @select-change="(value: string[]) => tabSelectChange"
       >
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.plugins="{ row }">
+        <template #value.plugins="{ row }: BaseTableCellParams<Row>">
           <t-space size="small">
             <t-tag v-for="(value, key) in row.value.plugins" :key="key" variant="light-outline">
               {{ key }}
@@ -46,24 +47,24 @@
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.create_time="{ row }">
+        <template #value.create_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.create_time).format('L LT') }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.update_time="{ row }">
+        <template #value.update_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.update_time).format('L LT') }}
         </template>
 
-        <template #op="slotProps: BaseTableCellParams<Item>">
+        <template #op="slotProps: BaseTableCellParams<Row>">
           <t-space>
-            <t-link theme="primary" @click="handleClickView(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickView(slotProps)">
               {{ t('pages.apisixGlobalRule.operations.view') }}</t-link
             >
-            <t-link theme="primary" @click="handleClickEdit(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickEdit(slotProps)">
               {{ t('pages.apisixGlobalRule.operations.edit') }}</t-link
             >
-            <t-link theme="danger" @click="handleClickDelete(slotProps)">
+            <t-link theme="danger" @click="tabRowOnClickDelete(slotProps)">
               {{ t('pages.apisixGlobalRule.operations.delete') }}</t-link
             >
           </t-space>
@@ -72,30 +73,35 @@
     </t-card>
 
     <t-dialog
-      v-model:visible="confirmVisible"
+      v-model:visible="delModalVisible"
       :header="t('pages.apisixGlobalRule.deleteConfirm.header')"
-      :on-cancel="onCancel"
-      @confirm="onConfirmDelete"
+      :on-cancel="delModalOnCancel"
+      @confirm="delModalOnConfirm"
     >
-      <p v-if="deleteIdx.length === 1">
+      <p v-if="toDelRowKeys.length === 1">
         {{
           t('pages.apisixGlobalRule.deleteConfirm.deleteOne', {
-            name: data[deleteIdx[0]]?.value?.id,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
           })
         }}
       </p>
-      <p v-if="deleteIdx.length > 1">
+      <p v-if="toDelRowKeys.length > 1">
         {{
           t('pages.apisixGlobalRule.deleteConfirm.deleteMulti', {
-            name: data[deleteIdx[0]]?.value?.id,
-            num: deleteIdx.length,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
+            num: toDelRowKeys.length,
           })
         }}
       </p>
     </t-dialog>
 
-    <t-drawer v-model:visible="drawerVisible" :header="drawerHeader" :on-confirm="onDrawerClickConfirm" size="medium">
-      <code-editor v-model:value="drawerBody" language="json" />
+    <t-drawer v-model:visible="viewDrawerVisible" :header="viewDrawerHeader" size="medium">
+      <code-editor v-model:value="viewDrawerContent" language="json" />
+      <template #footer>
+        <t-button theme="primary" @click="viewDrawerVisible = false">
+          {{ t('pages.apisixGlobalRule.viewConfirm') }}
+        </t-button>
+      </template>
     </t-drawer>
   </div>
 </template>
@@ -107,226 +113,149 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { AxiosPromise } from 'axios';
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
-import { BaseTableCellParams, MessagePlugin, PrimaryTableCol, TableProps, TableRowData } from 'tdesign-vue-next';
+import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { GlobalRuleApi } from '@/api/apisix/admin';
-import {
-  ApisixAdminGlobalRulesGet200ResponseListInner as Item,
-  ApisixAdminRoutesIdDelete200Response,
-} from '@/api/apisix/admin/typescript-axios';
+import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
 import CodeEditor from '@/components/code-editor/index.vue';
 import { prefix } from '@/config/global';
 import { t } from '@/locales';
 import { useSettingStore } from '@/store';
 
-const store = useSettingStore();
+import type { Row, RowPK } from './table';
+import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-const COLUMNS: PrimaryTableCol<TableRowData>[] = [
-  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
-  {
-    title: t('pages.apisixGlobalRule.root.key'),
-    colKey: 'key',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixGlobalRule.root.createdIndex'),
-    colKey: 'createdIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixGlobalRule.root.modifiedIndex'),
-    colKey: 'modifiedIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixGlobalRule.value.id'),
-    colKey: 'value.id',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixGlobalRule.value.plugins'),
-    colKey: 'value.plugins',
-  },
-  {
-    title: t('pages.apisixGlobalRule.value.create_time'),
-    colKey: 'value.create_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixGlobalRule.value.update_time'),
-    colKey: 'value.update_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixGlobalRule.operation'),
-    align: 'left',
-    fixed: 'right',
-    colKey: 'op',
-    width: 160,
-  },
-];
-const staticColumn: string[] = ['row-select', 'op'];
-const displayColumns = ref<TableProps['displayColumns']>(
-  staticColumn.concat(['value.id', 'value.desc', 'value.content']),
-);
-const columnControllerConfig = computed<TableProps['columnController']>(() => ({
-  // 列配置按钮位置
-  placement: 'top-right',
-  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
-  fields: undefined,
-  // 弹框组件属性透传
-  dialogProps: {
-    preventScrollThrough: true,
-  },
-  // 列配置按钮组件属性透传
-  buttonProps: undefined,
-  // 数据字段分组显示
-  groupColumns: [
-    {
-      label: 'root',
-      value: 'root',
-      columns: ['key', 'createdIndex', 'modifiedIndex'],
-    },
-    {
-      label: 'value',
-      value: 'value',
-      columns: ['value.id', 'value.plugins', 'value.create_time', 'value.update_time'],
-    },
-  ],
-}));
+onMounted(() => {
+  tabRefresh();
+});
 
-const data = ref<Item[]>([]);
-const pagination = ref({
+const router = useRouter();
+
+// #region Table
+
+const tabPagination = ref({
   defaultPageSize: 20,
   total: 100,
   defaultCurrent: 1,
 });
+const tabSearchValue = ref('');
+const tabData = ref<Row[]>([]);
+const tabDataLoading = ref(false);
+const tabSelectedRowKeys = ref<RowPK[]>([]);
 
-const searchValue = ref('');
+const tabSelectChange: TableProps['onSelectChange'] = (selectedRowKey, options) => {
+  tabSelectedRowKeys.value = selectedRowKey.slice() as RowPK[];
+};
 
-const dataLoading = ref(false);
-const fetchData = async () => {
-  dataLoading.value = true;
+const tabRefresh = async () => {
+  tabDataLoading.value = true;
   try {
-    const res = await GlobalRuleApi.apisixAdminGlobalRulesGet({
-      params: {
-        page: pagination.value.defaultCurrent,
-        page_size: pagination.value.defaultPageSize,
-      },
-    });
-    let { list } = res.data;
-    // fix: when apisix returns list as {}
-    if (!(list instanceof Array)) {
-      list = [];
-    }
-
-    data.value = list;
-    pagination.value = {
-      ...pagination.value,
-      total: list.length,
+    const resData = await fetchData(undefined, tabPagination.value);
+    tabData.value = resData.list;
+    tabPagination.value = {
+      ...tabPagination.value,
+      total: resData.total,
     };
   } catch (e) {
     console.error(e);
   }
-  dataLoading.value = false;
+  tabDataLoading.value = false;
 };
 
-const deleteIdx = ref<number[]>([]);
+// #endregion Table
 
-onMounted(() => {
-  fetchData();
-});
+// #region Delete
 
-const confirmVisible = ref(false);
+const toDelRowKeys = ref<RowPK[]>([]);
+const delModalVisible = ref(false);
 
-const selectedRowKeys = ref<string[]>([]);
-
-const router = useRouter();
-
-const resetIdx = () => {
-  deleteIdx.value = [];
+const delReset = () => {
+  toDelRowKeys.value = [];
 };
 
-const onConfirmDelete = async () => {
-  // 真实业务请发起请求
-  const ps: AxiosPromise<ApisixAdminRoutesIdDelete200Response>[] = [];
-  deleteIdx.value.forEach((rowIndex) => {
-    const { id } = data.value[rowIndex].value;
-    const p = GlobalRuleApi.apisixAdminGlobalRulesIdDelete({
-      id: id.toString(), // fix: apisix openapi
-      force: 'false',
-    });
+const delModalOnCancel = () => {
+  delReset();
+};
+
+const delModalOnConfirm = async () => {
+  const ps: Promise<ApisixAdminRoutesIdDelete200Response>[] = [];
+  toDelRowKeys.value.forEach((rowKey) => {
+    const row = tabData.value.find((e) => e.key === rowKey);
+    const p = deleteRow(row);
     ps.push(p);
   });
-  const resArr = await Promise.all(ps);
+  const resDataArr = await Promise.all(ps); // TODO: 报告成功和失败情况
 
-  const successResArr = resArr.filter((res) => {
-    return res.status === 200 && res.data.deleted;
-  });
+  const successResDataArr = resDataArr.filter((d) => d.deleted);
 
-  resetIdx();
-  confirmVisible.value = false;
-  MessagePlugin.success(t('pages.apisixGlobalRule.deleteMessage.success', { num: successResArr.length }));
+  delReset();
+  delModalVisible.value = false;
+  MessagePlugin.success(t('pages.apisixGlobalRule.deleteMessage.success', { num: successResDataArr.length }));
 
-  await fetchData();
+  await tabRefresh();
 };
 
-const onCancel = () => {
-  resetIdx();
+const opOnClickDelete = () => {
+  toDelRowKeys.value = tabSelectedRowKeys.value.slice();
+  delModalVisible.value = true;
 };
 
-const rowKey = 'key';
+const tabRowOnClickDelete = (slotProps: BaseTableCellParams<Row>) => {
+  toDelRowKeys.value = [slotProps.row.key];
+  delModalVisible.value = true;
+};
 
-const rehandleSelectChange = (val: string[]) => {
-  selectedRowKeys.value = val;
-};
-const rehandlePageChange = (curr: unknown, pageInfo: unknown) => {
-  console.log('分页变化', curr, pageInfo);
-};
-const rehandleChange = (changeParams: unknown, triggerAndData: unknown) => {
-  console.log('统一Change', changeParams, triggerAndData);
-};
-const handleClickView = (slotProps: BaseTableCellParams<Item>) => {
-  drawerHeader.value = slotProps.row.value.id.toString(); // fix: apisix openapi
-  drawerBody.value = JSON.stringify(slotProps.row.value, null, 2);
-  drawerVisible.value = true;
-};
-const handleClickEdit = (slotProps: BaseTableCellParams<Item>) => {
-  router.push(`/apisix/globalRule/edit?id=${slotProps.row.value.id}`);
-};
-const handleCreate = () => {
+// #endregion Delete
+
+// #region Create
+
+const opClickCreate = () => {
   router.push('/apisix/globalRule/edit');
 };
-const handleClickDelete = (slotProps: BaseTableCellParams<Item>) => {
-  deleteIdx.value = [slotProps.rowIndex];
-  confirmVisible.value = true;
+
+// #endregion Create
+
+// #region Edit
+
+const tabRowOnClickEdit = (slotProps: BaseTableCellParams<Row>) => {
+  router.push(`/apisix/globalRule/edit?id=${slotProps.row.value.id}`);
 };
 
+// #endregion Edit
+
+// #region Export
+
+const opClickExport = () => {
+  // TODO
+};
+
+// #endregion Export
+
+// #region View
+
+const viewDrawerVisible = ref(false);
+const viewDrawerHeader = ref('');
+const viewDrawerContent = ref('');
+
+const tabRowOnClickView = (slotProps: BaseTableCellParams<Row>) => {
+  viewDrawerHeader.value = slotProps.row.value.id as string;
+  viewDrawerContent.value = JSON.stringify(slotProps.row.value, null, 2);
+  viewDrawerVisible.value = true;
+};
+
+// #endregion View
+
+const settingStore = useSettingStore();
 const headerAffixedTop = computed(
   () =>
     ({
-      offsetTop: store.isUseTabsRouter ? 48 : 0,
+      offsetTop: settingStore.isUseTabsRouter ? 48 : 0,
       container: `.${prefix}-layout`,
     }) as any,
 );
-
-const drawerVisible = ref(false);
-const drawerHeader = ref('');
-const drawerBody = ref('');
-
-const onDrawerClickConfirm = () => {
-  MessagePlugin.info('数据保存中...', 1000);
-  const timer = setTimeout(() => {
-    clearTimeout(timer);
-    drawerVisible.value = false;
-    MessagePlugin.info('数据保存成功!');
-  }, 1000);
-};
 </script>
 
 <style lang="less" scoped>

--- a/src/pages/apisix/global_rule/index.vue
+++ b/src/pages/apisix/global_rule/index.vue
@@ -4,10 +4,10 @@
       <t-row justify="space-between">
         <div class="left-operation-container">
           <t-button @click="opClickCreate"> {{ t('pages.apisixGlobalRule.create') }} </t-button>
-          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
             {{ t('pages.apisixGlobalRule.delete') }}
           </t-button>
-          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
             {{ t('pages.apisixGlobalRule.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">

--- a/src/pages/apisix/global_rule/index.vue
+++ b/src/pages/apisix/global_rule/index.vue
@@ -116,7 +116,7 @@ export default {
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onActivated, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
@@ -128,7 +128,7 @@ import { useSettingStore } from '@/store';
 import type { Row, RowPK } from './table';
 import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-onMounted(() => {
+onActivated(() => {
   tabRefresh();
 });
 

--- a/src/pages/apisix/global_rule/table.ts
+++ b/src/pages/apisix/global_rule/table.ts
@@ -1,0 +1,156 @@
+import { Mutable } from '@vueuse/core';
+import { PaginationProps, TableProps } from 'tdesign-vue-next';
+import { ref } from 'vue';
+
+import { GlobalRuleApi } from '@/api/apisix/admin';
+import { ApisixAdminGlobalRulesGet200ResponseListInner } from '@/api/apisix/admin/typescript-axios';
+import { t } from '@/locales';
+
+// #region Table Columns
+
+/**
+ * 表格行的数据类型
+ */
+export type Row = ApisixAdminGlobalRulesGet200ResponseListInner;
+/**
+ * 表格行的主键键名
+ */
+export const ROW_PK: keyof Row = 'key';
+/**
+ * 表格行的主键类型
+ */
+export type RowPK = Row[typeof ROW_PK];
+
+export type Column = TableProps['columns'] & {
+  defaultHidden?: boolean;
+  canModifyHidden?: boolean;
+};
+
+export const COLUMNS: TableProps['columns'] = [
+  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
+  {
+    title: t('pages.apisixGlobalRule.root.key'),
+    colKey: 'key',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixGlobalRule.root.createdIndex'),
+    colKey: 'createdIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixGlobalRule.root.modifiedIndex'),
+    colKey: 'modifiedIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixGlobalRule.value.id'),
+    colKey: 'value.id',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixGlobalRule.value.plugins'),
+    colKey: 'value.plugins',
+  },
+  {
+    title: t('pages.apisixGlobalRule.value.create_time'),
+    colKey: 'value.create_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixGlobalRule.value.update_time'),
+    colKey: 'value.update_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixGlobalRule.operation'),
+    align: 'left',
+    fixed: 'right',
+    colKey: 'op',
+    width: 160,
+  },
+];
+
+/**
+ * 固定展示列
+ */
+const FIXED_DISPLAY_COLUMNS: string[] = ['row-select', 'op'];
+
+/**
+ * 展示列
+ */
+export const DISPLAY_COLUMNS = ref<TableProps['displayColumns']>([
+  ...FIXED_DISPLAY_COLUMNS,
+  'value.id',
+  'value.desc',
+  'value.content',
+]);
+
+export const COLUMN_CONTROLLER = ref<TableProps['columnController']>({
+  // 列配置按钮位置
+  placement: 'top-right',
+  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
+  fields: undefined,
+  // 弹框组件属性透传
+  dialogProps: {
+    preventScrollThrough: true,
+  },
+  // 列配置按钮组件属性透传
+  buttonProps: undefined,
+  // 数据字段分组显示
+  groupColumns: [
+    {
+      label: 'root',
+      value: 'root',
+      columns: ['key', 'createdIndex', 'modifiedIndex'],
+    },
+    {
+      label: 'value',
+      value: 'value',
+      columns: ['value.id', 'value.plugins', 'value.create_time', 'value.update_time'],
+    },
+  ],
+});
+
+// #endregion Table Columns
+
+// #region Table Data Action
+
+// 筛选器表单的数据类型
+export type SearchFormData = Mutable<void>; // TODO
+
+export const fetchData = async (searchFormData: SearchFormData, paginationInfo: PaginationProps) => {
+  try {
+    const res = await GlobalRuleApi.apisixAdminGlobalRulesGet({
+      params: {
+        page: paginationInfo.current,
+        page_size: paginationInfo.pageSize,
+      },
+    });
+
+    // fix: when empty, apisix returns list as {}
+    if (res.data.total === 0 && !(res.data.list instanceof Array)) {
+      res.data.list = [];
+    }
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch data:', error);
+    throw error;
+  }
+};
+
+export const deleteRow = async (row: Row) => {
+  try {
+    const res = await GlobalRuleApi.apisixAdminGlobalRulesIdDelete({
+      // id: row.value.id,
+      id: row.value.id as string, // fix: apisix openapi is empty interface
+      force: 'false',
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to delete row:', error);
+    throw error;
+  }
+};
+
+// #endregion Table Data Action

--- a/src/pages/apisix/proto/index.vue
+++ b/src/pages/apisix/proto/index.vue
@@ -3,12 +3,12 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="opClickCreate"> {{ t('pages.apisixProto.create') }} </t-button>
+          <t-button @click="opClickCreate"> {{ t('pages.apisixProto.operations.create') }} </t-button>
           <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
-            {{ t('pages.apisixProto.delete') }}
+            {{ t('pages.apisixProto.operations.delete') }}
           </t-button>
           <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
-            {{ t('pages.apisixProto.export') }}</t-button
+            {{ t('pages.apisixProto.operations.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixProto.selectedCount', { num: tabSelectedRowKeys.length }) }}

--- a/src/pages/apisix/proto/index.vue
+++ b/src/pages/apisix/proto/index.vue
@@ -4,10 +4,10 @@
       <t-row justify="space-between">
         <div class="left-operation-container">
           <t-button @click="opClickCreate"> {{ t('pages.apisixProto.create') }} </t-button>
-          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
             {{ t('pages.apisixProto.delete') }}
           </t-button>
-          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
             {{ t('pages.apisixProto.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">

--- a/src/pages/apisix/proto/index.vue
+++ b/src/pages/apisix/proto/index.vue
@@ -102,7 +102,7 @@ export default {
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onActivated, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
@@ -114,7 +114,7 @@ import { useSettingStore } from '@/store';
 import type { Row, RowPK } from './table';
 import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-onMounted(() => {
+onActivated(() => {
   tabRefresh();
 });
 

--- a/src/pages/apisix/proto/index.vue
+++ b/src/pages/apisix/proto/index.vue
@@ -3,16 +3,19 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="handleCreate"> {{ t('pages.apisixProto.create') }} </t-button>
-          <t-button variant="base" theme="default" :disabled="!selectedRowKeys.length">
+          <t-button @click="opClickCreate"> {{ t('pages.apisixProto.create') }} </t-button>
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+            {{ t('pages.apisixProto.delete') }}
+          </t-button>
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
             {{ t('pages.apisixProto.export') }}</t-button
           >
-          <p v-if="!!selectedRowKeys.length" class="selected-count">
-            {{ t('pages.apisixProto.selectedCount', { num: selectedRowKeys.length }) }}
+          <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
+            {{ t('pages.apisixProto.selectedCount', { num: tabSelectedRowKeys.length }) }}
           </p>
         </div>
         <div class="search-input">
-          <t-input v-model="searchValue" :placeholder="t('pages.apisixProto.placeholder')" clearable>
+          <t-input v-model="tabSearchValue" :placeholder="t('pages.apisixProto.placeholder')" clearable>
             <template #suffix-icon>
               <search-icon size="16px" />
             </template>
@@ -20,41 +23,39 @@
         </div>
       </t-row>
       <t-table
-        v-model:displayColumns="displayColumns"
-        :data="data"
+        v-model:display-columns="DISPLAY_COLUMNS"
+        :data="tabData"
         :columns="COLUMNS"
-        :column-controller="columnControllerConfig"
-        :row-key="rowKey"
+        :column-controller="COLUMN_CONTROLLER"
+        :row-key="ROW_PK"
         vertical-align="top"
         :hover="true"
-        :pagination="pagination"
-        :selected-row-keys="selectedRowKeys"
-        :loading="dataLoading"
+        :pagination="tabPagination"
+        :selected-row-keys="tabSelectedRowKeys"
+        :loading="tabDataLoading"
         :header-affixed-top="headerAffixedTop"
         table-layout="auto"
-        @page-change="rehandlePageChange"
-        @change="rehandleChange"
-        @select-change="(value: string[]) => rehandleSelectChange(value)"
+        @select-change="tabSelectChange"
       >
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.create_time="{ row }">
+        <template #value.create_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.create_time).format('L LT') }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.update_time="{ row }">
+        <template #value.update_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.update_time).format('L LT') }}
         </template>
 
-        <template #op="slotProps: BaseTableCellParams<Item>">
+        <template #op="slotProps: BaseTableCellParams<Row>">
           <t-space>
-            <t-link theme="primary" @click="handleClickView(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickView(slotProps)">
               {{ t('pages.apisixProto.operations.view') }}</t-link
             >
-            <t-link theme="primary" @click="handleClickEdit(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickEdit(slotProps)">
               {{ t('pages.apisixProto.operations.edit') }}</t-link
             >
-            <t-link theme="danger" @click="handleClickDelete(slotProps)">
+            <t-link theme="danger" @click="tabRowOnClickDelete(slotProps)">
               {{ t('pages.apisixProto.operations.delete') }}</t-link
             >
           </t-space>
@@ -63,30 +64,30 @@
     </t-card>
 
     <t-dialog
-      v-model:visible="confirmVisible"
+      v-model:visible="delModalVisible"
       :header="t('pages.apisixProto.deleteConfirm.header')"
-      :on-cancel="onCancel"
-      @confirm="onConfirmDelete"
+      :on-cancel="delModalOnCancel"
+      @confirm="delModalOnConfirm"
     >
-      <p v-if="deleteIdx.length === 1">
+      <p v-if="toDelRowKeys.length === 1">
         {{
           t('pages.apisixProto.deleteConfirm.deleteOne', {
-            name: data[deleteIdx[0]]?.value?.id,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
           })
         }}
       </p>
-      <p v-if="deleteIdx.length > 1">
+      <p v-if="toDelRowKeys.length > 1">
         {{
           t('pages.apisixProto.deleteConfirm.deleteMulti', {
-            name: data[deleteIdx[0]]?.value?.id,
-            num: deleteIdx.length,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
+            num: toDelRowKeys.length,
           })
         }}
       </p>
     </t-dialog>
 
-    <t-drawer v-model:visible="drawerVisible" :header="drawerHeader" :on-confirm="onDrawerClickConfirm" size="medium">
-      <code-editor v-model:value="drawerBody" language="json" />
+    <t-drawer v-model:visible="viewDrawerVisible" :header="viewDrawerHeader" size="medium">
+      <code-editor v-model:value="viewDrawerContent" language="json" />
     </t-drawer>
   </div>
 </template>
@@ -98,230 +99,149 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { AxiosPromise } from 'axios';
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
-import { BaseTableCellParams, MessagePlugin, PrimaryTableCol, TableProps, TableRowData } from 'tdesign-vue-next';
+import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { ProtoApi } from '@/api/apisix/admin';
-import {
-  ApisixAdminProtosIdGet200Response as Item,
-  ApisixAdminRoutesIdDelete200Response,
-} from '@/api/apisix/admin/typescript-axios';
+import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
 import CodeEditor from '@/components/code-editor/index.vue';
 import { prefix } from '@/config/global';
 import { t } from '@/locales';
 import { useSettingStore } from '@/store';
 
-const store = useSettingStore();
+import type { Row, RowPK } from './table';
+import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-const COLUMNS: PrimaryTableCol<TableRowData>[] = [
-  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
-  {
-    title: t('pages.apisixProto.root.key'),
-    colKey: 'key',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixProto.root.createdIndex'),
-    colKey: 'createdIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixProto.root.modifiedIndex'),
-    colKey: 'modifiedIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixProto.value.id'),
-    colKey: 'value.id',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixProto.value.desc'),
-    colKey: 'value.desc',
-  },
-  {
-    title: t('pages.apisixProto.value.content'),
-    colKey: 'value.content',
-  },
-  {
-    title: t('pages.apisixProto.value.create_time'),
-    colKey: 'value.create_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixProto.value.update_time'),
-    colKey: 'value.update_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixProto.operation'),
-    align: 'left',
-    fixed: 'right',
-    colKey: 'op',
-    width: 160,
-  },
-];
-const staticColumn: string[] = ['row-select', 'op'];
-const displayColumns = ref<TableProps['displayColumns']>(
-  staticColumn.concat(['value.id', 'value.desc', 'value.content']),
-);
-const columnControllerConfig = computed<TableProps['columnController']>(() => ({
-  // 列配置按钮位置
-  placement: 'top-right',
-  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
-  fields: undefined,
-  // 弹框组件属性透传
-  dialogProps: {
-    preventScrollThrough: true,
-  },
-  // 列配置按钮组件属性透传
-  buttonProps: undefined,
-  // 数据字段分组显示
-  groupColumns: [
-    {
-      label: 'root',
-      value: 'root',
-      columns: ['key', 'createdIndex', 'modifiedIndex'],
-    },
-    {
-      label: 'value',
-      value: 'value',
-      columns: ['value.id', 'value.desc', 'value.content', 'value.create_time', 'value.update_time'],
-    },
-  ],
-}));
+onMounted(() => {
+  tabRefresh();
+});
 
-const data = ref<Item[]>([]);
-const pagination = ref({
+const router = useRouter();
+
+// #region Table
+
+const tabPagination = ref({
   defaultPageSize: 20,
   total: 100,
   defaultCurrent: 1,
 });
+const tabSearchValue = ref('');
+const tabData = ref<Row[]>([]);
+const tabDataLoading = ref(false);
+const tabSelectedRowKeys = ref<RowPK[]>([]);
 
-const searchValue = ref('');
+const tabSelectChange: TableProps['onSelectChange'] = (selectedRowKey, options) => {
+  tabSelectedRowKeys.value = selectedRowKey.slice() as RowPK[];
+};
 
-const dataLoading = ref(false);
-const fetchData = async () => {
-  dataLoading.value = true;
+const tabRefresh = async () => {
+  tabDataLoading.value = true;
   try {
-    const res = await ProtoApi.apisixAdminProtosGet({
-      params: {
-        page: pagination.value.defaultCurrent,
-        page_size: pagination.value.defaultPageSize,
-      },
-    });
-    let { list } = res.data;
-    // fix: when apisix returns list as {}
-    if (!(list instanceof Array)) {
-      list = [];
-    }
-
-    data.value = list;
-    pagination.value = {
-      ...pagination.value,
-      total: list.length,
+    const resData = await fetchData(undefined, tabPagination.value);
+    tabData.value = resData.list;
+    tabPagination.value = {
+      ...tabPagination.value,
+      total: resData.total,
     };
   } catch (e) {
     console.error(e);
   }
-  dataLoading.value = false;
+  tabDataLoading.value = false;
 };
 
-const deleteIdx = ref<number[]>([]);
+// #endregion Table
 
-onMounted(() => {
-  fetchData();
-});
+// #region Delete
 
-const confirmVisible = ref(false);
+const toDelRowKeys = ref<RowPK[]>([]);
+const delModalVisible = ref(false);
 
-const selectedRowKeys = ref<string[]>([]);
-
-const router = useRouter();
-
-const resetIdx = () => {
-  deleteIdx.value = [];
+const delReset = () => {
+  toDelRowKeys.value = [];
 };
 
-const onConfirmDelete = async () => {
-  // 真实业务请发起请求
-  const ps: AxiosPromise<ApisixAdminRoutesIdDelete200Response>[] = [];
-  deleteIdx.value.forEach((rowIndex) => {
-    const { id } = data.value[rowIndex].value;
-    const p = ProtoApi.apisixAdminProtosIdDelete({
-      id: id.toString(), // fix: apisix openapi
-      force: 'false',
-    });
+const delModalOnCancel = () => {
+  delReset();
+};
+
+const delModalOnConfirm = async () => {
+  const ps: Promise<ApisixAdminRoutesIdDelete200Response>[] = [];
+  toDelRowKeys.value.forEach((rowKey) => {
+    const row = tabData.value.find((e) => e.key === rowKey);
+    const p = deleteRow(row);
     ps.push(p);
   });
-  const resArr = await Promise.all(ps);
+  const resDataArr = await Promise.all(ps); // TODO: 报告成功和失败情况
 
-  const successResArr = resArr.filter((res) => {
-    return res.status === 200 && res.data.deleted;
-  });
+  const successResDataArr = resDataArr.filter((d) => d.deleted);
 
-  resetIdx();
-  confirmVisible.value = false;
-  MessagePlugin.success(t('pages.apisixProto.deleteMessage.success', { num: successResArr.length }));
+  delReset();
+  delModalVisible.value = false;
+  MessagePlugin.success(t('pages.apisixProto.deleteMessage.success', { num: successResDataArr.length }));
 
-  await fetchData();
+  await tabRefresh();
 };
 
-const onCancel = () => {
-  resetIdx();
+const opOnClickDelete = () => {
+  toDelRowKeys.value = tabSelectedRowKeys.value.slice();
+  delModalVisible.value = true;
 };
 
-const rowKey = 'key';
+const tabRowOnClickDelete = (slotProps: BaseTableCellParams<Row>) => {
+  toDelRowKeys.value = [slotProps.row.key];
+  delModalVisible.value = true;
+};
 
-const rehandleSelectChange = (val: string[]) => {
-  selectedRowKeys.value = val;
-};
-const rehandlePageChange = (curr: unknown, pageInfo: unknown) => {
-  console.log('分页变化', curr, pageInfo);
-};
-const rehandleChange = (changeParams: unknown, triggerAndData: unknown) => {
-  console.log('统一Change', changeParams, triggerAndData);
-};
-const handleClickView = (slotProps: BaseTableCellParams<Item>) => {
-  drawerHeader.value = slotProps.row.value.id.toString(); // fix: apisix openapi
-  drawerBody.value = JSON.stringify(slotProps.row.value, null, 2);
-  drawerVisible.value = true;
-};
-const handleClickEdit = (slotProps: BaseTableCellParams<Item>) => {
-  router.push(`/apisix/proto/edit?id=${slotProps.row.value.id}`);
-};
-const handleCreate = () => {
+// #endregion Delete
+
+// #region Create
+
+const opClickCreate = () => {
   router.push('/apisix/proto/edit');
 };
-const handleClickDelete = (slotProps: BaseTableCellParams<Item>) => {
-  deleteIdx.value = [slotProps.rowIndex];
-  confirmVisible.value = true;
+
+// #endregion Create
+
+// #region Edit
+
+const tabRowOnClickEdit = (slotProps: BaseTableCellParams<Row>) => {
+  router.push(`/apisix/proto/edit?id=${slotProps.row.value.id}`);
 };
 
+// #endregion Edit
+
+// #region Export
+
+const opClickExport = () => {
+  // TODO
+};
+
+// #endregion Export
+
+// #region View
+
+const viewDrawerVisible = ref(false);
+const viewDrawerHeader = ref('');
+const viewDrawerContent = ref('');
+
+const tabRowOnClickView = (slotProps: BaseTableCellParams<Row>) => {
+  viewDrawerHeader.value = slotProps.row.value.id as string;
+  viewDrawerContent.value = JSON.stringify(slotProps.row.value, null, 2);
+  viewDrawerVisible.value = true;
+};
+
+// #endregion View
+
+const settingsStore = useSettingStore();
 const headerAffixedTop = computed(
   () =>
     ({
-      offsetTop: store.isUseTabsRouter ? 48 : 0,
+      offsetTop: settingsStore.isUseTabsRouter ? 48 : 0,
       container: `.${prefix}-layout`,
     }) as any,
 );
-
-const drawerVisible = ref(false);
-const drawerHeader = ref('');
-const drawerBody = ref('');
-
-const onDrawerClickConfirm = () => {
-  MessagePlugin.info('数据保存中...', 1000);
-  const timer = setTimeout(() => {
-    clearTimeout(timer);
-    drawerVisible.value = false;
-    MessagePlugin.info('数据保存成功!');
-  }, 1000);
-};
 </script>
 
 <style lang="less" scoped>

--- a/src/pages/apisix/proto/table.ts
+++ b/src/pages/apisix/proto/table.ts
@@ -1,0 +1,160 @@
+import { Mutable } from '@vueuse/core';
+import { PaginationProps, TableProps } from 'tdesign-vue-next';
+import { ref } from 'vue';
+
+import { ProtoApi } from '@/api/apisix/admin';
+import { ApisixAdminProtosIdGet200Response } from '@/api/apisix/admin/typescript-axios';
+import { t } from '@/locales';
+
+// #region Table Columns
+
+/**
+ * 表格行的数据类型
+ */
+export type Row = ApisixAdminProtosIdGet200Response;
+/**
+ * 表格行的主键键名
+ */
+export const ROW_PK: keyof Row = 'key';
+/**
+ * 表格行的主键类型
+ */
+export type RowPK = Row[typeof ROW_PK];
+
+export type Column = TableProps['columns'] & {
+  defaultHidden?: boolean;
+  canModifyHidden?: boolean;
+};
+
+export const COLUMNS: TableProps['columns'] = [
+  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
+  {
+    title: t('pages.apisixProto.root.key'),
+    colKey: 'key',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixProto.root.createdIndex'),
+    colKey: 'createdIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixProto.root.modifiedIndex'),
+    colKey: 'modifiedIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixProto.value.id'),
+    colKey: 'value.id',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixProto.value.desc'),
+    colKey: 'value.desc',
+  },
+  {
+    title: t('pages.apisixProto.value.content'),
+    colKey: 'value.content',
+  },
+  {
+    title: t('pages.apisixProto.value.create_time'),
+    colKey: 'value.create_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixProto.value.update_time'),
+    colKey: 'value.update_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixProto.operation'),
+    align: 'left',
+    fixed: 'right',
+    colKey: 'op',
+    width: 160,
+  },
+];
+
+/**
+ * 固定展示列
+ */
+const FIXED_DISPLAY_COLUMNS: string[] = ['row-select', 'op'];
+
+/**
+ * 展示列
+ */
+export const DISPLAY_COLUMNS = ref<TableProps['displayColumns']>([
+  ...FIXED_DISPLAY_COLUMNS,
+  'value.id',
+  'value.desc',
+  'value.content',
+]);
+
+export const COLUMN_CONTROLLER = ref<TableProps['columnController']>({
+  // 列配置按钮位置
+  placement: 'top-right',
+  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
+  fields: undefined,
+  // 弹框组件属性透传
+  dialogProps: {
+    preventScrollThrough: true,
+  },
+  // 列配置按钮组件属性透传
+  buttonProps: undefined,
+  // 数据字段分组显示
+  groupColumns: [
+    {
+      label: 'root',
+      value: 'root',
+      columns: ['key', 'createdIndex', 'modifiedIndex'],
+    },
+    {
+      label: 'value',
+      value: 'value',
+      columns: ['value.id', 'value.desc', 'value.content', 'value.create_time', 'value.update_time'],
+    },
+  ],
+});
+
+// #endregion Table Columns
+
+// #region Table Data Action
+
+// 筛选器表单的数据类型
+export type SearchFormData = Mutable<void>; // TODO
+
+export const fetchData = async (searchFormData: SearchFormData, paginationInfo: PaginationProps) => {
+  try {
+    const res = await ProtoApi.apisixAdminProtosGet({
+      params: {
+        page: paginationInfo.current,
+        page_size: paginationInfo.pageSize,
+      },
+    });
+
+    // fix: when empty, apisix returns list as {}
+    if (res.data.total === 0 && !(res.data.list instanceof Array)) {
+      res.data.list = [];
+    }
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch data:', error);
+    throw error;
+  }
+};
+
+export const deleteRow = async (row: Row) => {
+  try {
+    const res = await ProtoApi.apisixAdminProtosIdDelete({
+      // id: row.value.id,
+      id: row.value.id as string, // fix: apisix openapi is empty interface
+      force: 'false',
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to delete row:', error);
+    throw error;
+  }
+};
+
+// #endregion Table Data Action

--- a/src/pages/apisix/route/index.vue
+++ b/src/pages/apisix/route/index.vue
@@ -4,10 +4,10 @@
       <t-row justify="space-between">
         <div class="left-operation-container">
           <t-button @click="opClickCreate"> {{ t('pages.apisixRoute.create') }} </t-button>
-          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
             {{ t('pages.apisixRoute.delete') }}
           </t-button>
-          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
             {{ t('pages.apisixRoute.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">

--- a/src/pages/apisix/route/index.vue
+++ b/src/pages/apisix/route/index.vue
@@ -3,12 +3,12 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="opClickCreate"> {{ t('pages.apisixRoute.create') }} </t-button>
+          <t-button @click="opClickCreate"> {{ t('pages.apisixRoute.operations.create') }} </t-button>
           <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
-            {{ t('pages.apisixRoute.delete') }}
+            {{ t('pages.apisixRoute.operations.delete') }}
           </t-button>
           <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
-            {{ t('pages.apisixRoute.export') }}</t-button
+            {{ t('pages.apisixRoute.operations.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixRoute.selectedCount', { num: tabSelectedRowKeys.length }) }}

--- a/src/pages/apisix/route/table.ts
+++ b/src/pages/apisix/route/table.ts
@@ -1,0 +1,219 @@
+import { Mutable } from '@vueuse/core';
+import { PaginationProps, SwitchValue, TableProps } from 'tdesign-vue-next';
+import { ref } from 'vue';
+
+import { RouteApi } from '@/api/apisix/admin';
+import {
+  ApisixAdminRoutesGet200ResponseListInner,
+  ApisixAdminRoutesGet200ResponseListInnerValueStatus,
+} from '@/api/apisix/admin/typescript-axios';
+import { t } from '@/locales';
+
+// #region Table Columns
+
+/**
+ * 表格行的数据类型
+ */
+export type Row = ApisixAdminRoutesGet200ResponseListInner;
+/**
+ * 表格行的主键键名
+ */
+export const ROW_PK: keyof Row = 'key';
+/**
+ * 表格行的主键类型
+ */
+export type RowPK = Row[typeof ROW_PK];
+
+export type Column = TableProps['columns'] & {
+  defaultHidden?: boolean;
+  canModifyHidden?: boolean;
+};
+
+export const COLUMNS: TableProps['columns'] = [
+  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
+  {
+    title: t('pages.apisixRoute.root.key'),
+    colKey: 'key',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixRoute.root.createdIndex'),
+    colKey: 'createdIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixRoute.root.modifiedIndex'),
+    colKey: 'modifiedIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixRoute.value.name'),
+    colKey: 'value.name',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixRoute.value.id'),
+    colKey: 'value.id',
+  },
+  {
+    title: t('pages.apisixRoute.value.host'),
+    colKey: 'value.host',
+  },
+  {
+    title: t('pages.apisixRoute.value.uri'),
+    colKey: 'value.uri',
+  },
+  {
+    title: t('pages.apisixRoute.value.desc'),
+    colKey: 'value.desc',
+  },
+  {
+    title: t('pages.apisixRoute.value.labels'),
+    colKey: 'value.labels',
+  },
+  // {
+  //   title: t('pages.apisixRoute.value.API_VERSION'),
+  //   colKey: 'value.API_VERSION',
+  // },
+  {
+    title: t('pages.apisixRoute.value.status'),
+    colKey: 'value.status',
+  },
+  {
+    title: t('pages.apisixRoute.value.plugins'),
+    colKey: 'value.plugins',
+  },
+  // {
+  //   title: t('pages.apisixRoute.value.create_time'),
+  //   colKey: 'value.create_time',
+  //   width: 240,
+  // },
+  // {
+  //   title: t('pages.apisixRoute.value.update_time'),
+  //   colKey: 'value.update_time',
+  //   width: 240,
+  // },
+  {
+    title: t('pages.apisixRoute.operation'),
+    align: 'left',
+    fixed: 'right',
+    colKey: 'op',
+    width: 160,
+  },
+];
+
+/**
+ * 固定展示列
+ */
+const FIXED_DISPLAY_COLUMNS: string[] = ['row-select', 'op'];
+
+/**
+ * 展示列
+ */
+export const DISPLAY_COLUMNS = ref<TableProps['displayColumns']>([
+  ...FIXED_DISPLAY_COLUMNS,
+  'value.name',
+  'value.id',
+  'value.host',
+  'value.uri',
+  'value.desc',
+  'value.labels',
+  'value.status',
+  'value.plugins',
+]);
+
+export const COLUMN_CONTROLLER = ref<TableProps['columnController']>({
+  // 列配置按钮位置
+  placement: 'top-right',
+  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
+  fields: undefined,
+  // 弹框组件属性透传
+  dialogProps: {
+    preventScrollThrough: true,
+  },
+  // 列配置按钮组件属性透传
+  buttonProps: undefined,
+  // 数据字段分组显示
+  groupColumns: [
+    {
+      label: 'root',
+      value: 'root',
+      columns: ['key', 'createdIndex', 'modifiedIndex'],
+    },
+    {
+      label: 'value',
+      value: 'value',
+      columns: [
+        'value.name',
+        'value.id',
+        'value.host',
+        'value.uri',
+        'value.desc',
+        'value.labels',
+        'value.status',
+        'value.plugins',
+        // 'value.create_time',
+        // 'value.update_time',
+      ],
+    },
+  ],
+});
+
+// #endregion Table Columns
+
+// #region Table Data Action
+
+// 筛选器表单的数据类型
+export type SearchFormData = Mutable<void>; // TODO
+
+export const fetchData = async (searchFormData: SearchFormData, paginationInfo: PaginationProps) => {
+  try {
+    const res = await RouteApi.apisixAdminRoutesGet({
+      params: {
+        page: paginationInfo.current,
+        page_size: paginationInfo.pageSize,
+      },
+    });
+
+    // fix: when empty, apisix returns list as {}
+    if (res.data.total === 0 && !(res.data.list instanceof Array)) {
+      res.data.list = [];
+    }
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch data:', error);
+    throw error;
+  }
+};
+
+export const deleteRow = async (row: Row) => {
+  try {
+    const res = await RouteApi.apisixAdminRoutesIdDelete({
+      // id: row.value.id,
+      id: row.value.id as string, // fix: apisix openapi is empty interface
+      force: 'false',
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to delete row:', error);
+    throw error;
+  }
+};
+
+export const updateRowStatus = async (row: Row, status: SwitchValue) => {
+  try {
+    const res = await RouteApi.apisixAdminRoutesIdPatch({
+      // id: row.value.id,
+      id: row.value.id as string, // fix: apisix openapi is empty interface
+      apisixAdminRoutesPostRequest: {
+        status: status as ApisixAdminRoutesGet200ResponseListInnerValueStatus,
+      },
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to update row status:', error);
+    throw error;
+  }
+};
+
+// #endregion Table Data Action

--- a/src/pages/apisix/secret/index.vue
+++ b/src/pages/apisix/secret/index.vue
@@ -3,16 +3,19 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="handleCreate"> {{ t('pages.apisixSecret.create') }} </t-button>
-          <t-button variant="base" theme="default" :disabled="!selectedRowKeys.length">
+          <t-button @click="opClickCreate"> {{ t('pages.apisixSecret.create') }} </t-button>
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+            {{ t('pages.apisixSecret.delete') }}
+          </t-button>
+          <t-button variant="base" theme="default" :disabled="!tabSelectedRowKeys.length" @click="opClickExport">
             {{ t('pages.apisixSecret.export') }}</t-button
           >
-          <p v-if="!!selectedRowKeys.length" class="selected-count">
-            {{ t('pages.apisixSecret.selectedCount', { num: selectedRowKeys.length }) }}
+          <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
+            {{ t('pages.apisixSecret.selectedCount', { num: tabSelectedRowKeys.length }) }}
           </p>
         </div>
         <div class="search-input">
-          <t-input v-model="searchValue" :placeholder="t('pages.apisixSecret.placeholder')" clearable>
+          <t-input v-model="tabSearchValue" :placeholder="t('pages.apisixSecret.placeholder')" clearable>
             <template #suffix-icon>
               <search-icon size="16px" />
             </template>
@@ -20,53 +23,51 @@
         </div>
       </t-row>
       <t-table
-        v-model:displayColumns="displayColumns"
-        :data="data"
+        v-model:display-columns="DISPLAY_COLUMNS"
+        :data="tabData"
         :columns="COLUMNS"
-        :column-controller="columnControllerConfig"
-        :row-key="rowKey"
+        :column-controller="COLUMN_CONTROLLER"
+        :row-key="ROW_PK"
         vertical-align="top"
         :hover="true"
-        :pagination="pagination"
-        :selected-row-keys="selectedRowKeys"
-        :loading="dataLoading"
+        :pagination="tabPagination"
+        :selected-row-keys="tabSelectedRowKeys"
+        :loading="tabDataLoading"
         :header-affixed-top="headerAffixedTop"
         table-layout="auto"
-        @page-change="rehandlePageChange"
-        @change="rehandleChange"
-        @select-change="(value: string[]) => rehandleSelectChange(value)"
+        @select-change="tabSelectChange"
       >
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.secretManager="{ row }">
+        <template #value.secretManager="{ row }: BaseTableCellParams<Row>">
           <!-- API 接口的id字段格式是 "{secretmanager}/{id}" 这里做拆分 -->
           {{ row.value.id.split('/', 2)[0] }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.name="{ row }">
+        <template #value.name="{ row }: BaseTableCellParams<Row>">
           <!-- API 接口的id字段格式是 "{secretmanager}/{id}" 这里做拆分 -->
           {{ row.value.id.split('/', 2)[1] }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.create_time="{ row }">
+        <template #value.create_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.create_time).format('L LT') }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.update_time="{ row }">
+        <template #value.update_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.update_time).format('L LT') }}
         </template>
 
-        <template #op="slotProps: BaseTableCellParams<Item>">
+        <template #op="slotProps: BaseTableCellParams<Row>">
           <t-space>
-            <t-link theme="primary" @click="handleClickView(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickView(slotProps)">
               {{ t('pages.apisixSecret.operations.view') }}</t-link
             >
-            <t-link theme="primary" @click="handleClickEdit(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickEdit(slotProps)">
               {{ t('pages.apisixSecret.operations.edit') }}</t-link
             >
-            <t-link theme="danger" @click="handleClickDelete(slotProps)">
+            <t-link theme="danger" @click="tabRowOnClickDelete(slotProps)">
               {{ t('pages.apisixSecret.operations.delete') }}</t-link
             >
           </t-space>
@@ -75,30 +76,30 @@
     </t-card>
 
     <t-dialog
-      v-model:visible="confirmVisible"
+      v-model:visible="delModalVisible"
       :header="t('pages.apisixSecret.deleteConfirm.header')"
-      :on-cancel="onCancel"
-      @confirm="onConfirmDelete"
+      :on-cancel="delModalOnCancel"
+      @confirm="delModalOnConfirm"
     >
-      <p v-if="deleteIdx.length === 1">
+      <p v-if="toDelRowKeys.length === 1">
         {{
           t('pages.apisixSecret.deleteConfirm.deleteOne', {
-            name: data[deleteIdx[0]]?.value?.id,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
           })
         }}
       </p>
-      <p v-if="deleteIdx.length > 1">
+      <p v-if="toDelRowKeys.length > 1">
         {{
           t('pages.apisixSecret.deleteConfirm.deleteMulti', {
-            name: data[deleteIdx[0]]?.value?.id,
-            num: deleteIdx.length,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
+            num: toDelRowKeys.length,
           })
         }}
       </p>
     </t-dialog>
 
-    <t-drawer v-model:visible="drawerVisible" :header="drawerHeader" :on-confirm="onDrawerClickConfirm" size="medium">
-      <code-editor v-model:value="drawerBody" language="json" />
+    <t-drawer v-model:visible="viewDrawerVisible" :header="viewDrawerHeader" size="medium">
+      <code-editor v-model:value="viewDrawerContent" language="json" />
     </t-drawer>
   </div>
 </template>
@@ -110,255 +111,151 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { AxiosPromise } from 'axios';
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
-import { BaseTableCellParams, MessagePlugin, PrimaryTableCol, TableProps, TableRowData } from 'tdesign-vue-next';
+import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { SecretApi } from '@/api/apisix/admin';
-import {
-  ApisixAdminRoutesIdDelete200Response,
-  ApisixAdminSecretsGet200ResponseListInner as Item,
-} from '@/api/apisix/admin/typescript-axios';
+import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
 import CodeEditor from '@/components/code-editor/index.vue';
 import { prefix } from '@/config/global';
 import { t } from '@/locales';
 import { useSettingStore } from '@/store';
 
-const store = useSettingStore();
+import type { Row, RowPK } from './table';
+import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-const COLUMNS: PrimaryTableCol<TableRowData>[] = [
-  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
-  {
-    title: t('pages.apisixSecret.root.key'),
-    colKey: 'key',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixSecret.root.createdIndex'),
-    colKey: 'createdIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixSecret.root.modifiedIndex'),
-    colKey: 'modifiedIndex',
-    fixed: 'left',
-  },
-  // <!-- API 接口的id字段格式是 "{secretmanager}/{id}" 这里是接口原始字段 -->
-  {
-    title: t('pages.apisixSecret.value.id'),
-    colKey: 'value.id',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixSecret.value.secretManager'),
-    colKey: 'value.secretManager',
-  },
-  {
-    title: t('pages.apisixSecret.value.name'),
-    colKey: 'value.name',
-  },
-  {
-    title: t('pages.apisixSecret.value.uri'),
-    colKey: 'value.uri',
-  },
-  {
-    title: t('pages.apisixSecret.value.prefix'),
-    colKey: 'value.prefix',
-  },
-  {
-    title: t('pages.apisixSecret.value.token'),
-    colKey: 'value.token',
-  },
-  {
-    title: t('pages.apisixSecret.value.create_time'),
-    colKey: 'value.create_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixSecret.value.update_time'),
-    colKey: 'value.update_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixSecret.operation'),
-    align: 'left',
-    fixed: 'right',
-    colKey: 'op',
-    width: 160,
-  },
-];
-const staticColumn: string[] = ['row-select', 'op'];
-const displayColumns = ref<TableProps['displayColumns']>(
-  staticColumn.concat(['value.id', 'value.secretManager', 'value.name', 'value.uri', 'value.prefix', 'value.token']),
-);
-const columnControllerConfig = computed<TableProps['columnController']>(() => ({
-  // 列配置按钮位置
-  placement: 'top-right',
-  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
-  fields: undefined,
-  // 弹框组件属性透传
-  dialogProps: {
-    preventScrollThrough: true,
-  },
-  // 列配置按钮组件属性透传
-  buttonProps: undefined,
-  // 数据字段分组显示
-  groupColumns: [
-    {
-      label: 'root',
-      value: 'root',
-      columns: ['key', 'createdIndex', 'modifiedIndex'],
-    },
-    {
-      label: 'value',
-      value: 'value',
-      columns: [
-        'value.id',
-        'value.secretManager',
-        'value.name',
-        'value.uri',
-        'value.prefix',
-        'value.token',
-        'value.create_time',
-        'value.update_time',
-      ],
-    },
-  ],
-}));
+onMounted(() => {
+  tabRefresh();
+});
 
-const data = ref<Item[]>([]);
-const pagination = ref({
+const router = useRouter();
+
+// #region Table
+
+const tabPagination = ref({
   defaultPageSize: 20,
   total: 100,
   defaultCurrent: 1,
 });
+const tabSearchValue = ref('');
+const tabData = ref<Row[]>([]);
+const tabDataLoading = ref(false);
+const tabSelectedRowKeys = ref<RowPK[]>([]);
 
-const searchValue = ref('');
+const tabSelectChange: TableProps['onSelectChange'] = (selectedRowKey, options) => {
+  tabSelectedRowKeys.value = selectedRowKey.slice() as RowPK[];
+};
 
-const dataLoading = ref(false);
-const fetchData = async () => {
-  dataLoading.value = true;
+const tabRefresh = async () => {
+  tabDataLoading.value = true;
   try {
-    const res = await SecretApi.apisixAdminSecretsGet({
-      params: {
-        page: pagination.value.defaultCurrent,
-        page_size: pagination.value.defaultPageSize,
-      },
-    });
-    let { list } = res.data;
-    // fix: when apisix returns list as {}
-    if (!(list instanceof Array)) {
-      list = [];
-    }
-
-    data.value = list;
-    pagination.value = {
-      ...pagination.value,
-      total: list.length,
+    const resData = await fetchData(undefined, tabPagination.value);
+    tabData.value = resData.list;
+    tabPagination.value = {
+      ...tabPagination.value,
+      total: resData.total,
     };
   } catch (e) {
     console.error(e);
   }
-  dataLoading.value = false;
+  tabDataLoading.value = false;
 };
 
-const deleteIdx = ref<number[]>([]);
+// #endregion Table
 
-onMounted(() => {
-  fetchData();
-});
+// #region Delete
 
-const confirmVisible = ref(false);
+const toDelRowKeys = ref<RowPK[]>([]);
+const delModalVisible = ref(false);
 
-const selectedRowKeys = ref<string[]>([]);
-
-const router = useRouter();
-
-const resetIdx = () => {
-  deleteIdx.value = [];
+const delReset = () => {
+  toDelRowKeys.value = [];
 };
 
-const onConfirmDelete = async () => {
-  // 真实业务请发起请求
-  const ps: AxiosPromise<ApisixAdminRoutesIdDelete200Response>[] = [];
-  deleteIdx.value.forEach((rowIndex) => {
-    const { id } = data.value[rowIndex].value;
-    const p = SecretApi.apisixAdminSecretsSecretmanagerIdDelete({
-      secretmanager: id.toString(), // TODO
-      id,
-      force: 'false',
-    });
+const delModalOnCancel = () => {
+  delReset();
+};
+
+const delModalOnConfirm = async () => {
+  const ps: Promise<ApisixAdminRoutesIdDelete200Response>[] = [];
+  toDelRowKeys.value.forEach((rowKey) => {
+    const row = tabData.value.find((e) => e.key === rowKey);
+    const p = deleteRow(row);
     ps.push(p);
   });
-  const resArr = await Promise.all(ps);
+  const resDataArr = await Promise.all(ps); // TODO: 报告成功和失败情况
 
-  const successResArr = resArr.filter((res) => {
-    return res.status === 200 && res.data.deleted;
-  });
+  const successResDataArr = resDataArr.filter((d) => d.deleted);
 
-  resetIdx();
-  confirmVisible.value = false;
-  MessagePlugin.success(t('pages.apisixSecret.deleteMessage.success', { num: successResArr.length }));
+  delReset();
+  delModalVisible.value = false;
+  MessagePlugin.success(t('pages.apisixSecret.deleteMessage.success', { num: successResDataArr.length }));
 
-  await fetchData();
+  await tabRefresh();
 };
 
-const onCancel = () => {
-  resetIdx();
+const opOnClickDelete = () => {
+  toDelRowKeys.value = tabSelectedRowKeys.value.slice();
+  delModalVisible.value = true;
 };
 
-const rowKey = 'key';
+const tabRowOnClickDelete = (slotProps: BaseTableCellParams<Row>) => {
+  toDelRowKeys.value = [slotProps.row.key];
+  delModalVisible.value = true;
+};
 
-const rehandleSelectChange = (val: string[]) => {
-  selectedRowKeys.value = val;
+// #endregion Delete
+
+// #region Create
+
+const opClickCreate = () => {
+  router.push('/apisix/secret/edit');
 };
-const rehandlePageChange = (curr: unknown, pageInfo: unknown) => {
-  console.log('分页变化', curr, pageInfo);
-};
-const rehandleChange = (changeParams: unknown, triggerAndData: unknown) => {
-  console.log('统一Change', changeParams, triggerAndData);
-};
-const handleClickView = (slotProps: BaseTableCellParams<Item>) => {
-  drawerHeader.value = slotProps.row.value.id;
-  drawerBody.value = JSON.stringify(slotProps.row.value, null, 2);
-  drawerVisible.value = true;
-};
-const handleClickEdit = (slotProps: BaseTableCellParams<Item>) => {
+
+// #endregion Create
+
+// #region Edit
+
+const tabRowOnClickEdit = (slotProps: BaseTableCellParams<Row>) => {
   // <!-- API 接口的id字段格式是 "{secretmanager}/{id}" 这里做拆分 -->
   const [secretmanager, id] = slotProps.row.value.id.split('/', 2);
   router.push(`/apisix/secret/edit?secretmanager=${secretmanager}&id=${id}`);
 };
-const handleCreate = () => {
-  router.push('/apisix/secret/edit');
-};
-const handleClickDelete = (slotProps: BaseTableCellParams<Item>) => {
-  deleteIdx.value = [slotProps.rowIndex];
-  confirmVisible.value = true;
+
+// #endregion Edit
+
+// #region Export
+
+const opClickExport = () => {
+  // TODO
 };
 
+// #endregion Export
+
+// #region View
+
+const viewDrawerVisible = ref(false);
+const viewDrawerHeader = ref('');
+const viewDrawerContent = ref('');
+
+const tabRowOnClickView = (slotProps: BaseTableCellParams<Row>) => {
+  viewDrawerHeader.value = slotProps.row.value.id;
+  viewDrawerContent.value = JSON.stringify(slotProps.row.value, null, 2);
+  viewDrawerVisible.value = true;
+};
+
+// #endregion View
+
+const settingsStore = useSettingStore();
 const headerAffixedTop = computed(
   () =>
     ({
-      offsetTop: store.isUseTabsRouter ? 48 : 0,
+      offsetTop: settingsStore.isUseTabsRouter ? 48 : 0,
       container: `.${prefix}-layout`,
     }) as any,
 );
-
-const drawerVisible = ref(false);
-const drawerHeader = ref('');
-const drawerBody = ref('');
-
-const onDrawerClickConfirm = () => {
-  MessagePlugin.info('数据保存中...', 1000);
-  const timer = setTimeout(() => {
-    clearTimeout(timer);
-    drawerVisible.value = false;
-    MessagePlugin.info('数据保存成功!');
-  }, 1000);
-};
 </script>
 
 <style lang="less" scoped>

--- a/src/pages/apisix/secret/index.vue
+++ b/src/pages/apisix/secret/index.vue
@@ -4,10 +4,10 @@
       <t-row justify="space-between">
         <div class="left-operation-container">
           <t-button @click="opClickCreate"> {{ t('pages.apisixSecret.create') }} </t-button>
-          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
             {{ t('pages.apisixSecret.delete') }}
           </t-button>
-          <t-button variant="base" theme="default" :disabled="!tabSelectedRowKeys.length" @click="opClickExport">
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
             {{ t('pages.apisixSecret.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">

--- a/src/pages/apisix/secret/index.vue
+++ b/src/pages/apisix/secret/index.vue
@@ -3,12 +3,12 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="opClickCreate"> {{ t('pages.apisixSecret.create') }} </t-button>
+          <t-button @click="opClickCreate"> {{ t('pages.apisixSecret.operations.create') }} </t-button>
           <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
-            {{ t('pages.apisixSecret.delete') }}
+            {{ t('pages.apisixSecret.operations.delete') }}
           </t-button>
           <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
-            {{ t('pages.apisixSecret.export') }}</t-button
+            {{ t('pages.apisixSecret.operations.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixSecret.selectedCount', { num: tabSelectedRowKeys.length }) }}

--- a/src/pages/apisix/secret/index.vue
+++ b/src/pages/apisix/secret/index.vue
@@ -114,7 +114,7 @@ export default {
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onActivated, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
@@ -126,7 +126,7 @@ import { useSettingStore } from '@/store';
 import type { Row, RowPK } from './table';
 import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-onMounted(() => {
+onActivated(() => {
   tabRefresh();
 });
 

--- a/src/pages/apisix/secret/table.ts
+++ b/src/pages/apisix/secret/table.ts
@@ -1,0 +1,191 @@
+import { Mutable } from '@vueuse/core';
+import { PaginationProps, TableProps } from 'tdesign-vue-next';
+import { ref } from 'vue';
+
+import { SecretApi } from '@/api/apisix/admin';
+import {
+  ApisixAdminSecretsGet200ResponseListInner,
+  ApisixAdminSecretsSecretmanagerIdGetSecretmanagerParameter,
+} from '@/api/apisix/admin/typescript-axios';
+import { t } from '@/locales';
+
+// #region Table Columns
+
+/**
+ * 表格行的数据类型
+ */
+export type Row = ApisixAdminSecretsGet200ResponseListInner;
+/**
+ * 表格行的主键键名
+ */
+export const ROW_PK: keyof Row = 'key';
+/**
+ * 表格行的主键类型
+ */
+export type RowPK = Row[typeof ROW_PK];
+
+export type Column = TableProps['columns'] & {
+  defaultHidden?: boolean;
+  canModifyHidden?: boolean;
+};
+
+export const COLUMNS: TableProps['columns'] = [
+  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
+  {
+    title: t('pages.apisixSecret.root.key'),
+    colKey: 'key',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixSecret.root.createdIndex'),
+    colKey: 'createdIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixSecret.root.modifiedIndex'),
+    colKey: 'modifiedIndex',
+    fixed: 'left',
+  },
+  // <!-- API 接口的id字段格式是 "{secretmanager}/{id}" 这里是接口原始字段 -->
+  {
+    title: t('pages.apisixSecret.value.id'),
+    colKey: 'value.id',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixSecret.value.secretManager'),
+    colKey: 'value.secretManager',
+  },
+  {
+    title: t('pages.apisixSecret.value.name'),
+    colKey: 'value.name',
+  },
+  {
+    title: t('pages.apisixSecret.value.uri'),
+    colKey: 'value.uri',
+  },
+  {
+    title: t('pages.apisixSecret.value.prefix'),
+    colKey: 'value.prefix',
+  },
+  {
+    title: t('pages.apisixSecret.value.token'),
+    colKey: 'value.token',
+  },
+  {
+    title: t('pages.apisixSecret.value.create_time'),
+    colKey: 'value.create_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixSecret.value.update_time'),
+    colKey: 'value.update_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixSecret.operation'),
+    align: 'left',
+    fixed: 'right',
+    colKey: 'op',
+    width: 160,
+  },
+];
+
+/**
+ * 固定展示列
+ */
+const FIXED_DISPLAY_COLUMNS: string[] = ['row-select', 'op'];
+
+/**
+ * 展示列
+ */
+export const DISPLAY_COLUMNS = ref<TableProps['displayColumns']>([
+  ...FIXED_DISPLAY_COLUMNS,
+  'value.id',
+  'value.secretManager',
+  'value.name',
+  'value.uri',
+  'value.prefix',
+  'value.token',
+]);
+
+export const COLUMN_CONTROLLER = ref<TableProps['columnController']>({
+  // 列配置按钮位置
+  placement: 'top-right',
+  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
+  fields: undefined,
+  // 弹框组件属性透传
+  dialogProps: {
+    preventScrollThrough: true,
+  },
+  // 列配置按钮组件属性透传
+  buttonProps: undefined,
+  // 数据字段分组显示
+  groupColumns: [
+    {
+      label: 'root',
+      value: 'root',
+      columns: ['key', 'createdIndex', 'modifiedIndex'],
+    },
+    {
+      label: 'value',
+      value: 'value',
+      columns: [
+        'value.id',
+        'value.secretManager',
+        'value.name',
+        'value.uri',
+        'value.prefix',
+        'value.token',
+        'value.create_time',
+        'value.update_time',
+      ],
+    },
+  ],
+});
+
+// #endregion Table Columns
+
+// #region Table Data Action
+
+// 筛选器表单的数据类型
+export type SearchFormData = Mutable<void>; // TODO
+
+export const fetchData = async (searchFormData: SearchFormData, paginationInfo: PaginationProps) => {
+  try {
+    const res = await SecretApi.apisixAdminSecretsGet({
+      params: {
+        page: paginationInfo.current,
+        page_size: paginationInfo.pageSize,
+      },
+    });
+
+    // fix: when empty, apisix returns list as {}
+    if (res.data.total === 0 && !(res.data.list instanceof Array)) {
+      res.data.list = [];
+    }
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch data:', error);
+    throw error;
+  }
+};
+
+export const deleteRow = async (row: Row) => {
+  try {
+    // <!-- API 接口的id字段格式是 "{secretmanager}/{id}" 这里做拆分 -->
+    const [secretmanager, id] = row.value.id.split('/', 2);
+
+    const res = await SecretApi.apisixAdminSecretsSecretmanagerIdDelete({
+      secretmanager: secretmanager as ApisixAdminSecretsSecretmanagerIdGetSecretmanagerParameter, // fix: apisix openapi is empty interface
+      id,
+      force: 'false',
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to delete row:', error);
+    throw error;
+  }
+};
+
+// #endregion Table Data Action

--- a/src/pages/apisix/service/index.vue
+++ b/src/pages/apisix/service/index.vue
@@ -3,12 +3,12 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="opClickCreate"> {{ t('pages.apisixService.create') }} </t-button>
+          <t-button @click="opClickCreate"> {{ t('pages.apisixService.operations.create') }} </t-button>
           <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
-            {{ t('pages.apisixService.delete') }}
+            {{ t('pages.apisixService.operations.delete') }}
           </t-button>
           <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
-            {{ t('pages.apisixService.export') }}</t-button
+            {{ t('pages.apisixService.operations.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixService.selectedCount', { num: tabSelectedRowKeys.length }) }}

--- a/src/pages/apisix/service/index.vue
+++ b/src/pages/apisix/service/index.vue
@@ -4,10 +4,10 @@
       <t-row justify="space-between">
         <div class="left-operation-container">
           <t-button @click="opClickCreate"> {{ t('pages.apisixService.create') }} </t-button>
-          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
             {{ t('pages.apisixService.delete') }}
           </t-button>
-          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
             {{ t('pages.apisixService.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">

--- a/src/pages/apisix/service/index.vue
+++ b/src/pages/apisix/service/index.vue
@@ -139,7 +139,7 @@ export default {
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onActivated, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
@@ -151,7 +151,7 @@ import { useSettingStore } from '@/store';
 import type { Row, RowPK } from './table';
 import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-onMounted(() => {
+onActivated(() => {
   tabRefresh();
 });
 

--- a/src/pages/apisix/service/index.vue
+++ b/src/pages/apisix/service/index.vue
@@ -3,16 +3,19 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="handleCreate"> {{ t('pages.apisixService.create') }} </t-button>
-          <t-button variant="base" theme="default" :disabled="!selectedRowKeys.length">
+          <t-button @click="opClickCreate"> {{ t('pages.apisixService.create') }} </t-button>
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+            {{ t('pages.apisixService.delete') }}
+          </t-button>
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
             {{ t('pages.apisixService.export') }}</t-button
           >
-          <p v-if="!!selectedRowKeys.length" class="selected-count">
-            {{ t('pages.apisixService.selectedCount', { num: selectedRowKeys.length }) }}
+          <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
+            {{ t('pages.apisixService.selectedCount', { num: tabSelectedRowKeys.length }) }}
           </p>
         </div>
         <div class="search-input">
-          <t-input v-model="searchValue" :placeholder="t('pages.apisixService.placeholder')" clearable>
+          <t-input v-model="tabSearchValue" :placeholder="t('pages.apisixService.placeholder')" clearable>
             <template #suffix-icon>
               <search-icon size="16px" />
             </template>
@@ -20,24 +23,22 @@
         </div>
       </t-row>
       <t-table
-        v-model:displayColumns="displayColumns"
-        :data="data"
+        v-model:display-columns="DISPLAY_COLUMNS"
+        :data="tabData"
         :columns="COLUMNS"
-        :column-controller="columnControllerConfig"
-        :row-key="rowKey"
+        :column-controller="COLUMN_CONTROLLER"
+        :row-key="ROW_PK"
         vertical-align="top"
         :hover="true"
-        :pagination="pagination"
-        :selected-row-keys="selectedRowKeys"
-        :loading="dataLoading"
+        :pagination="tabPagination"
+        :selected-row-keys="tabSelectedRowKeys"
+        :loading="tabDataLoading"
         :header-affixed-top="headerAffixedTop"
         table-layout="auto"
-        @page-change="rehandlePageChange"
-        @change="rehandleChange"
-        @select-change="(value: string[]) => rehandleSelectChange(value)"
+        @select-change="tabSelectChange"
       >
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.labels="{ row }">
+        <template #value.labels="{ row }: BaseTableCellParams<Row>">
           <t-space size="small">
             <t-tag v-for="(value, key) in row.value.labels" :key="key" variant="light-outline">
               {{ key }}:{{ value }}
@@ -46,7 +47,7 @@
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.plugins="{ row }">
+        <template #value.plugins="{ row }: BaseTableCellParams<Row>">
           <t-space size="small">
             <t-tag v-for="(value, key) in row.value.plugins" :key="key" variant="light-outline">
               {{ key }}
@@ -55,17 +56,17 @@
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.enable_websocket="{ row }">
-          <t-tag v-if="row.value.enable_websocket === 0" theme="danger" variant="light-outline">
-            {{ t('pages.apisixRoute.value.enable_websocketEnum.0') }}
+        <template #value.enable_websocket="{ row }: BaseTableCellParams<Row>">
+          <t-tag v-if="!row.value.enable_websocket" theme="danger" variant="light-outline">
+            {{ t('pages.apisixService.value.enable_websocketEnum.0') }}
           </t-tag>
-          <t-tag v-if="row.value.enable_websocket === 1" theme="success" variant="light-outline">
-            {{ t('pages.apisixRoute.value.enable_websocketEnum.1') }}
+          <t-tag v-if="row.value.enable_websocket" theme="success" variant="light-outline">
+            {{ t('pages.apisixService.value.enable_websocketEnum.1') }}
           </t-tag>
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.hosts="{ row }">
+        <template #value.hosts="{ row }: BaseTableCellParams<Row>">
           <t-space size="small">
             <t-tag v-for="(value, key) in row.value.hosts" :key="key" variant="light-outline">
               {{ value }}
@@ -74,7 +75,7 @@
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.create_time="{ row }">
+        <template #value.create_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.create_time).format('L LT') }}
         </template>
 
@@ -83,15 +84,15 @@
           {{ dayjs.unix(row.value.update_time).format('L LT') }}
         </template>
 
-        <template #op="slotProps: BaseTableCellParams<Item>">
+        <template #op="slotProps: BaseTableCellParams<Row>">
           <t-space>
-            <t-link theme="primary" @click="handleClickView(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickView(slotProps)">
               {{ t('pages.apisixService.operations.view') }}</t-link
             >
-            <t-link theme="primary" @click="handleClickEdit(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickEdit(slotProps)">
               {{ t('pages.apisixService.operations.edit') }}</t-link
             >
-            <t-link theme="danger" @click="handleClickDelete(slotProps)">
+            <t-link theme="danger" @click="tabRowOnClickDelete(slotProps)">
               {{ t('pages.apisixService.operations.delete') }}</t-link
             >
           </t-space>
@@ -100,30 +101,30 @@
     </t-card>
 
     <t-dialog
-      v-model:visible="confirmVisible"
+      v-model:visible="delModalVisible"
       :header="t('pages.apisixService.deleteConfirm.header')"
-      :on-cancel="onCancel"
-      @confirm="onConfirmDelete"
+      :on-cancel="delModalOnCancel"
+      @confirm="delModalOnConfirm"
     >
-      <p v-if="deleteIdx.length === 1">
+      <p v-if="toDelRowKeys.length === 1">
         {{
           t('pages.apisixService.deleteConfirm.deleteOne', {
-            name: data[deleteIdx[0]]?.value?.id,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
           })
         }}
       </p>
-      <p v-if="deleteIdx.length > 1">
+      <p v-if="toDelRowKeys.length > 1">
         {{
           t('pages.apisixService.deleteConfirm.deleteMulti', {
-            name: data[deleteIdx[0]]?.value?.id,
-            num: deleteIdx.length,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
+            num: toDelRowKeys.length,
           })
         }}
       </p>
     </t-dialog>
 
-    <t-drawer v-model:visible="drawerVisible" :header="drawerHeader" :on-confirm="onDrawerClickConfirm" size="medium">
-      <code-editor v-model:value="drawerBody" language="json" />
+    <t-drawer v-model:visible="viewDrawerVisible" :header="viewDrawerHeader" size="medium">
+      <code-editor v-model:value="viewDrawerContent" language="json" />
     </t-drawer>
   </div>
 </template>
@@ -135,279 +136,149 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { AxiosPromise } from 'axios';
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
-import { BaseTableCellParams, MessagePlugin, PrimaryTableCol, TableProps, TableRowData } from 'tdesign-vue-next';
+import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { ServiceApi } from '@/api/apisix/admin';
-import {
-  ApisixAdminRoutesIdDelete200Response,
-  ApisixAdminServicesGet200ResponseListInner as Item,
-} from '@/api/apisix/admin/typescript-axios';
+import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
 import CodeEditor from '@/components/code-editor/index.vue';
 import { prefix } from '@/config/global';
 import { t } from '@/locales';
 import { useSettingStore } from '@/store';
 
-const store = useSettingStore();
+import type { Row, RowPK } from './table';
+import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-const COLUMNS: PrimaryTableCol<TableRowData>[] = [
-  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
-  {
-    title: t('pages.apisixService.root.key'),
-    colKey: 'key',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixService.root.createdIndex'),
-    colKey: 'createdIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixService.root.modifiedIndex'),
-    colKey: 'modifiedIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixService.value.id'),
-    colKey: 'value.id',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixService.value.name'),
-    colKey: 'value.name',
-  },
-  {
-    title: t('pages.apisixService.value.desc'),
-    colKey: 'value.desc',
-  },
-  {
-    title: t('pages.apisixService.value.labels'),
-    colKey: 'value.labels',
-  },
-  {
-    title: t('pages.apisixService.value.upstream_id'),
-    colKey: 'value.upstream_id',
-  },
-  {
-    title: t('pages.apisixService.value.upstream'),
-    colKey: 'value.upstream',
-  },
-  {
-    title: t('pages.apisixService.value.plugins'),
-    colKey: 'value.plugins',
-  },
-  {
-    title: t('pages.apisixService.value.enable_websocket'),
-    colKey: 'value.enable_websocket',
-  },
-  {
-    title: t('pages.apisixService.value.script'),
-    colKey: 'value.script',
-  },
-  {
-    title: t('pages.apisixService.value.hosts'),
-    colKey: 'value.hosts',
-  },
-  {
-    title: t('pages.apisixService.value.create_time'),
-    colKey: 'value.create_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixService.value.update_time'),
-    colKey: 'value.update_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixService.operation'),
-    align: 'left',
-    fixed: 'right',
-    colKey: 'op',
-    width: 160,
-  },
-];
-const staticColumn: string[] = ['row-select', 'op'];
-const displayColumns = ref<TableProps['displayColumns']>(
-  staticColumn.concat([
-    'value.id',
-    'value.name',
-    'value.desc',
-    'value.labels',
-    'value.plugins',
-    'value.enable_websocket',
-    'value.hosts',
-  ]),
-);
-const columnControllerConfig = computed<TableProps['columnController']>(() => ({
-  // 列配置按钮位置
-  placement: 'top-right',
-  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
-  fields: undefined,
-  // 弹框组件属性透传
-  dialogProps: {
-    preventScrollThrough: true,
-  },
-  // 列配置按钮组件属性透传
-  buttonProps: undefined,
-  // 数据字段分组显示
-  groupColumns: [
-    {
-      label: 'root',
-      value: 'root',
-      columns: ['key', 'createdIndex', 'modifiedIndex'],
-    },
-    {
-      label: 'value',
-      value: 'value',
-      columns: [
-        'value.id',
-        'value.name',
-        'value.desc',
-        'value.labels',
-        'value.upstream_id',
-        'value.upstream',
-        'value.plugins',
-        'value.enable_websocket',
-        'value.script',
-        'value.hosts',
-        'value.create_time',
-        'value.update_time',
-      ],
-    },
-  ],
-}));
+onMounted(() => {
+  tabRefresh();
+});
 
-const data = ref<Item[]>([]);
-const pagination = ref({
+const router = useRouter();
+
+// #region Table
+
+const tabPagination = ref({
   defaultPageSize: 20,
   total: 100,
   defaultCurrent: 1,
 });
+const tabSearchValue = ref('');
+const tabData = ref<Row[]>([]);
+const tabDataLoading = ref(false);
+const tabSelectedRowKeys = ref<RowPK[]>([]);
 
-const searchValue = ref('');
+const tabSelectChange: TableProps['onSelectChange'] = (selectedRowKey, options) => {
+  tabSelectedRowKeys.value = selectedRowKey.slice() as RowPK[];
+};
 
-const dataLoading = ref(false);
-const fetchData = async () => {
-  dataLoading.value = true;
+const tabRefresh = async () => {
+  tabDataLoading.value = true;
   try {
-    const res = await ServiceApi.apisixAdminServicesGet({
-      params: {
-        page: pagination.value.defaultCurrent,
-        page_size: pagination.value.defaultPageSize,
-      },
-    });
-    let { list } = res.data;
-    // fix: when apisix returns list as {}
-    if (!(list instanceof Array)) {
-      list = [];
-    }
-
-    data.value = list;
-    pagination.value = {
-      ...pagination.value,
-      total: list.length,
+    const resData = await fetchData(undefined, tabPagination.value);
+    tabData.value = resData.list;
+    tabPagination.value = {
+      ...tabPagination.value,
+      total: resData.total,
     };
   } catch (e) {
     console.error(e);
   }
-  dataLoading.value = false;
+  tabDataLoading.value = false;
 };
 
-const deleteIdx = ref<number[]>([]);
+// #endregion Table
 
-onMounted(() => {
-  fetchData();
-});
+// #region Delete
 
-const confirmVisible = ref(false);
+const toDelRowKeys = ref<RowPK[]>([]);
+const delModalVisible = ref(false);
 
-const selectedRowKeys = ref<string[]>([]);
-
-const router = useRouter();
-
-const resetIdx = () => {
-  deleteIdx.value = [];
+const delReset = () => {
+  toDelRowKeys.value = [];
 };
 
-const onConfirmDelete = async () => {
-  // 真实业务请发起请求
-  const ps: AxiosPromise<ApisixAdminRoutesIdDelete200Response>[] = [];
-  deleteIdx.value.forEach((rowIndex) => {
-    const { id } = data.value[rowIndex].value;
-    const p = ServiceApi.apisixAdminServicesIdDelete({
-      id: id.toString(), // fix: apisix openapi
-      force: 'false',
-    });
+const delModalOnCancel = () => {
+  delReset();
+};
+
+const delModalOnConfirm = async () => {
+  const ps: Promise<ApisixAdminRoutesIdDelete200Response>[] = [];
+  toDelRowKeys.value.forEach((rowKey) => {
+    const row = tabData.value.find((e) => e.key === rowKey);
+    const p = deleteRow(row);
     ps.push(p);
   });
-  const resArr = await Promise.all(ps);
+  const resDataArr = await Promise.all(ps); // TODO: 报告成功和失败情况
 
-  const successResArr = resArr.filter((res) => {
-    return res.status === 200 && res.data.deleted;
-  });
+  const successResDataArr = resDataArr.filter((d) => d.deleted);
 
-  resetIdx();
-  confirmVisible.value = false;
-  MessagePlugin.success(t('pages.apisixService.deleteMessage.success', { num: successResArr.length }));
+  delReset();
+  delModalVisible.value = false;
+  MessagePlugin.success(t('pages.apisixService.deleteMessage.success', { num: successResDataArr.length }));
 
-  await fetchData();
+  await tabRefresh();
 };
 
-const onCancel = () => {
-  resetIdx();
+const opOnClickDelete = () => {
+  toDelRowKeys.value = tabSelectedRowKeys.value.slice();
+  delModalVisible.value = true;
 };
 
-const rowKey = 'key';
+const tabRowOnClickDelete = (slotProps: BaseTableCellParams<Row>) => {
+  toDelRowKeys.value = [slotProps.row.key];
+  delModalVisible.value = true;
+};
 
-const rehandleSelectChange = (val: string[]) => {
-  selectedRowKeys.value = val;
-};
-const rehandlePageChange = (curr: unknown, pageInfo: unknown) => {
-  console.log('分页变化', curr, pageInfo);
-};
-const rehandleChange = (changeParams: unknown, triggerAndData: unknown) => {
-  console.log('统一Change', changeParams, triggerAndData);
-};
-const handleClickView = (slotProps: BaseTableCellParams<Item>) => {
-  drawerHeader.value = slotProps.row.value.id.toString(); // fix: apisix openapi
-  drawerBody.value = JSON.stringify(slotProps.row.value, null, 2);
-  drawerVisible.value = true;
-};
-const handleClickEdit = (slotProps: BaseTableCellParams<Item>) => {
-  router.push(`/apisix/service/edit?id=${slotProps.row.value.id}`);
-};
-const handleCreate = () => {
+// #endregion Delete
+
+// #region Create
+
+const opClickCreate = () => {
   router.push('/apisix/service/edit');
 };
-const handleClickDelete = (slotProps: BaseTableCellParams<Item>) => {
-  deleteIdx.value = [slotProps.rowIndex];
-  confirmVisible.value = true;
+
+// #endregion Create
+
+// #region Edit
+
+const tabRowOnClickEdit = (slotProps: BaseTableCellParams<Row>) => {
+  router.push(`/apisix/service/edit?id=${slotProps.row.value.id}`);
 };
 
+// #endregion Edit
+
+// #region Export
+
+const opClickExport = () => {
+  // TODO
+};
+
+// #endregion Export
+
+// #region View
+
+const viewDrawerVisible = ref(false);
+const viewDrawerHeader = ref('');
+const viewDrawerContent = ref('');
+
+const tabRowOnClickView = (slotProps: BaseTableCellParams<Row>) => {
+  viewDrawerHeader.value = slotProps.row.value.id as string;
+  viewDrawerContent.value = JSON.stringify(slotProps.row.value, null, 2);
+  viewDrawerVisible.value = true;
+};
+
+// #endregion View
+
+const settingsStore = useSettingStore();
 const headerAffixedTop = computed(
   () =>
     ({
-      offsetTop: store.isUseTabsRouter ? 48 : 0,
+      offsetTop: settingsStore.isUseTabsRouter ? 48 : 0,
       container: `.${prefix}-layout`,
     }) as any,
 );
-
-const drawerVisible = ref(false);
-const drawerHeader = ref('');
-const drawerBody = ref('');
-
-const onDrawerClickConfirm = () => {
-  MessagePlugin.info('数据保存中...', 1000);
-  const timer = setTimeout(() => {
-    clearTimeout(timer);
-    drawerVisible.value = false;
-    MessagePlugin.info('数据保存成功!');
-  }, 1000);
-};
 </script>
 
 <style lang="less" scoped>

--- a/src/pages/apisix/service/table.ts
+++ b/src/pages/apisix/service/table.ts
@@ -1,0 +1,205 @@
+import { Mutable } from '@vueuse/core';
+import { PaginationProps, TableProps } from 'tdesign-vue-next';
+import { ref } from 'vue';
+
+import { ServiceApi } from '@/api/apisix/admin';
+import { ApisixAdminServicesGet200ResponseListInner } from '@/api/apisix/admin/typescript-axios';
+import { t } from '@/locales';
+
+// #region Table Columns
+
+/**
+ * 表格行的数据类型
+ */
+export type Row = ApisixAdminServicesGet200ResponseListInner;
+/**
+ * 表格行的主键键名
+ */
+export const ROW_PK: keyof Row = 'key';
+/**
+ * 表格行的主键类型
+ */
+export type RowPK = Row[typeof ROW_PK];
+
+export type Column = TableProps['columns'] & {
+  defaultHidden?: boolean;
+  canModifyHidden?: boolean;
+};
+
+export const COLUMNS: TableProps['columns'] = [
+  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
+  {
+    title: t('pages.apisixService.root.key'),
+    colKey: 'key',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixService.root.createdIndex'),
+    colKey: 'createdIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixService.root.modifiedIndex'),
+    colKey: 'modifiedIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixService.value.id'),
+    colKey: 'value.id',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixService.value.name'),
+    colKey: 'value.name',
+  },
+  {
+    title: t('pages.apisixService.value.desc'),
+    colKey: 'value.desc',
+  },
+  {
+    title: t('pages.apisixService.value.labels'),
+    colKey: 'value.labels',
+  },
+  {
+    title: t('pages.apisixService.value.upstream_id'),
+    colKey: 'value.upstream_id',
+  },
+  {
+    title: t('pages.apisixService.value.upstream'),
+    colKey: 'value.upstream',
+  },
+  {
+    title: t('pages.apisixService.value.plugins'),
+    colKey: 'value.plugins',
+  },
+  {
+    title: t('pages.apisixService.value.enable_websocket'),
+    colKey: 'value.enable_websocket',
+  },
+  {
+    title: t('pages.apisixService.value.script'),
+    colKey: 'value.script',
+  },
+  {
+    title: t('pages.apisixService.value.hosts'),
+    colKey: 'value.hosts',
+  },
+  {
+    title: t('pages.apisixService.value.create_time'),
+    colKey: 'value.create_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixService.value.update_time'),
+    colKey: 'value.update_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixService.operation'),
+    align: 'left',
+    fixed: 'right',
+    colKey: 'op',
+    width: 160,
+  },
+];
+
+/**
+ * 固定展示列
+ */
+const FIXED_DISPLAY_COLUMNS: string[] = ['row-select', 'op'];
+
+/**
+ * 展示列
+ */
+export const DISPLAY_COLUMNS = ref<TableProps['displayColumns']>([
+  ...FIXED_DISPLAY_COLUMNS,
+  'value.id',
+  'value.name',
+  'value.desc',
+  'value.labels',
+  'value.plugins',
+  'value.enable_websocket',
+  'value.hosts',
+]);
+
+export const COLUMN_CONTROLLER = ref<TableProps['columnController']>({
+  // 列配置按钮位置
+  placement: 'top-right',
+  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
+  fields: undefined,
+  // 弹框组件属性透传
+  dialogProps: {
+    preventScrollThrough: true,
+  },
+  // 列配置按钮组件属性透传
+  buttonProps: undefined,
+  // 数据字段分组显示
+  groupColumns: [
+    {
+      label: 'root',
+      value: 'root',
+      columns: ['key', 'createdIndex', 'modifiedIndex'],
+    },
+    {
+      label: 'value',
+      value: 'value',
+      columns: [
+        'value.id',
+        'value.name',
+        'value.desc',
+        'value.labels',
+        'value.upstream_id',
+        'value.upstream',
+        'value.plugins',
+        'value.enable_websocket',
+        'value.script',
+        'value.hosts',
+        'value.create_time',
+        'value.update_time',
+      ],
+    },
+  ],
+});
+
+// #endregion Table Columns
+
+// #region Table Data Action
+
+// 筛选器表单的数据类型
+export type SearchFormData = Mutable<void>; // TODO
+
+export const fetchData = async (searchFormData: SearchFormData, paginationInfo: PaginationProps) => {
+  try {
+    const res = await ServiceApi.apisixAdminServicesGet({
+      params: {
+        page: paginationInfo.current,
+        page_size: paginationInfo.pageSize,
+      },
+    });
+
+    // fix: when empty, apisix returns list as {}
+    if (res.data.total === 0 && !(res.data.list instanceof Array)) {
+      res.data.list = [];
+    }
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch data:', error);
+    throw error;
+  }
+};
+
+export const deleteRow = async (row: Row) => {
+  try {
+    const res = await ServiceApi.apisixAdminServicesIdDelete({
+      // id: row.value.id,
+      id: row.value.id as string, // fix: apisix openapi is empty interface
+      force: 'false',
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to delete row:', error);
+    throw error;
+  }
+};
+
+// #endregion Table Data Action

--- a/src/pages/apisix/ssl/index.vue
+++ b/src/pages/apisix/ssl/index.vue
@@ -107,7 +107,7 @@ export default {
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onActivated, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
@@ -119,7 +119,7 @@ import { useSettingStore } from '@/store';
 import type { Row, RowPK } from './table';
 import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-onMounted(() => {
+onActivated(() => {
   tabRefresh();
 });
 

--- a/src/pages/apisix/ssl/index.vue
+++ b/src/pages/apisix/ssl/index.vue
@@ -3,16 +3,19 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="handleCreate"> {{ t('pages.apisixSsl.create') }} </t-button>
-          <t-button variant="base" theme="default" :disabled="!selectedRowKeys.length">
+          <t-button @click="opClickCreate"> {{ t('pages.apisixSsl.create') }} </t-button>
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+            {{ t('pages.apisixSsl.delete') }}
+          </t-button>
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
             {{ t('pages.apisixSsl.export') }}</t-button
           >
-          <p v-if="!!selectedRowKeys.length" class="selected-count">
-            {{ t('pages.apisixSsl.selectedCount', { num: selectedRowKeys.length }) }}
+          <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
+            {{ t('pages.apisixSsl.selectedCount', { num: tabSelectedRowKeys.length }) }}
           </p>
         </div>
         <div class="search-input">
-          <t-input v-model="searchValue" :placeholder="t('pages.apisixSsl.placeholder')" clearable>
+          <t-input v-model="tabSearchValue" :placeholder="t('pages.apisixSsl.placeholder')" clearable>
             <template #suffix-icon>
               <search-icon size="16px" />
             </template>
@@ -20,44 +23,44 @@
         </div>
       </t-row>
       <t-table
-        v-model:displayColumns="displayColumns"
-        :data="data"
+        v-model:display-columns="DISPLAY_COLUMNS"
+        :data="tabData"
         :columns="COLUMNS"
-        :column-controller="columnControllerConfig"
-        :row-key="rowKey"
+        :column-controller="COLUMN_CONTROLLER"
+        :row-key="ROW_PK"
         vertical-align="top"
         :hover="true"
-        :pagination="pagination"
-        :selected-row-keys="selectedRowKeys"
-        :loading="dataLoading"
+        :pagination="tabPagination"
+        :selected-row-keys="tabSelectedRowKeys"
+        :loading="tabDataLoading"
         :header-affixed-top="headerAffixedTop"
         table-layout="auto"
-        @page-change="rehandlePageChange"
-        @change="rehandleChange"
-        @select-change="(value: string[]) => rehandleSelectChange(value)"
+        @select-change="tabSelectChange"
       >
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.expireTime="{ row }"> TODO {{ row.key }} </template>
-
-        <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.create_time="{ row }">
+        <template #value.expireTime="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.create_time).format('L LT') }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.update_time="{ row }">
+        <template #value.create_time="{ row }: BaseTableCellParams<Row>">
+          {{ dayjs.unix(row.value.create_time).format('L LT') }}
+        </template>
+
+        <!-- eslint-disable-next-line vue/valid-v-slot -->
+        <template #value.update_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.update_time).format('L LT') }}
         </template>
 
-        <template #op="slotProps: BaseTableCellParams<Item>">
+        <template #op="slotProps: BaseTableCellParams<Row>">
           <t-space>
-            <t-link theme="primary" @click="handleClickView(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickView(slotProps)">
               {{ t('pages.apisixSsl.operations.view') }}</t-link
             >
-            <t-link theme="primary" @click="handleClickEdit(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickEdit(slotProps)">
               {{ t('pages.apisixSsl.operations.edit') }}</t-link
             >
-            <t-link theme="danger" @click="handleClickDelete(slotProps)">
+            <t-link theme="danger" @click="tabRowOnClickDelete(slotProps)">
               {{ t('pages.apisixSsl.operations.delete') }}</t-link
             >
           </t-space>
@@ -66,30 +69,30 @@
     </t-card>
 
     <t-dialog
-      v-model:visible="confirmVisible"
+      v-model:visible="delModalVisible"
       :header="t('pages.apisixSsl.deleteConfirm.header')"
-      :on-cancel="onCancel"
-      @confirm="onConfirmDelete"
+      :on-cancel="delModalOnCancel"
+      @confirm="delModalOnConfirm"
     >
-      <p v-if="deleteIdx.length === 1">
+      <p v-if="toDelRowKeys.length === 1">
         {{
           t('pages.apisixSsl.deleteConfirm.deleteOne', {
-            name: data[deleteIdx[0]]?.value?.id,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
           })
         }}
       </p>
-      <p v-if="deleteIdx.length > 1">
+      <p v-if="toDelRowKeys.length > 1">
         {{
           t('pages.apisixSsl.deleteConfirm.deleteMulti', {
-            name: data[deleteIdx[0]]?.value?.id,
-            num: deleteIdx.length,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
+            num: toDelRowKeys.length,
           })
         }}
       </p>
     </t-dialog>
 
-    <t-drawer v-model:visible="drawerVisible" :header="drawerHeader" :on-confirm="onDrawerClickConfirm" size="medium">
-      <code-editor v-model:value="drawerBody" language="json" />
+    <t-drawer v-model:visible="viewDrawerVisible" :header="viewDrawerHeader" size="medium">
+      <code-editor v-model:value="viewDrawerContent" language="json" />
     </t-drawer>
   </div>
 </template>
@@ -101,230 +104,149 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { AxiosPromise } from 'axios';
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
-import { BaseTableCellParams, MessagePlugin, PrimaryTableCol, TableProps, TableRowData } from 'tdesign-vue-next';
+import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { SSLApi } from '@/api/apisix/admin';
-import {
-  ApisixAdminRoutesIdDelete200Response,
-  ApisixAdminSslsGet200ResponseListInner as Item,
-} from '@/api/apisix/admin/typescript-axios';
+import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
 import CodeEditor from '@/components/code-editor/index.vue';
 import { prefix } from '@/config/global';
 import { t } from '@/locales';
 import { useSettingStore } from '@/store';
 
-const store = useSettingStore();
+import type { Row, RowPK } from './table';
+import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-const COLUMNS: PrimaryTableCol<TableRowData>[] = [
-  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
-  {
-    title: t('pages.apisixSsl.root.key'),
-    colKey: 'key',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixSsl.root.createdIndex'),
-    colKey: 'createdIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixSsl.root.modifiedIndex'),
-    colKey: 'modifiedIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixSsl.value.id'),
-    colKey: 'value.id',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixSsl.value.sni'),
-    colKey: 'value.sni',
-  },
-  {
-    title: t('pages.apisixSsl.value.expireTime'),
-    colKey: 'value.expireTime',
-  },
-  {
-    title: t('pages.apisixSsl.value.create_time'),
-    colKey: 'value.create_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixSsl.value.update_time'),
-    colKey: 'value.update_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixSsl.operation'),
-    align: 'left',
-    fixed: 'right',
-    colKey: 'op',
-    width: 160,
-  },
-];
-const staticColumn: string[] = ['row-select', 'op'];
-const displayColumns = ref<TableProps['displayColumns']>(
-  staticColumn.concat(['value.id', 'value.sni', 'value.expireTime', 'value.update_time']),
-);
-const columnControllerConfig = computed<TableProps['columnController']>(() => ({
-  // 列配置按钮位置
-  placement: 'top-right',
-  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
-  fields: undefined,
-  // 弹框组件属性透传
-  dialogProps: {
-    preventScrollThrough: true,
-  },
-  // 列配置按钮组件属性透传
-  buttonProps: undefined,
-  // 数据字段分组显示
-  groupColumns: [
-    {
-      label: 'root',
-      value: 'root',
-      columns: ['key', 'createdIndex', 'modifiedIndex'],
-    },
-    {
-      label: 'value',
-      value: 'value',
-      columns: ['value.id', 'value.sni', 'value.expireTime', 'value.create_time', 'value.update_time'],
-    },
-  ],
-}));
+onMounted(() => {
+  tabRefresh();
+});
 
-const data = ref<Item[]>([]);
-const pagination = ref({
+const router = useRouter();
+
+// #region Table
+
+const tabPagination = ref({
   defaultPageSize: 20,
   total: 100,
   defaultCurrent: 1,
 });
+const tabSearchValue = ref('');
+const tabData = ref<Row[]>([]);
+const tabDataLoading = ref(false);
+const tabSelectedRowKeys = ref<RowPK[]>([]);
 
-const searchValue = ref('');
+const tabSelectChange: TableProps['onSelectChange'] = (selectedRowKey, options) => {
+  tabSelectedRowKeys.value = selectedRowKey.slice() as RowPK[];
+};
 
-const dataLoading = ref(false);
-const fetchData = async () => {
-  dataLoading.value = true;
+const tabRefresh = async () => {
+  tabDataLoading.value = true;
   try {
-    const res = await SSLApi.apisixAdminSslsGet({
-      params: {
-        page: pagination.value.defaultCurrent,
-        page_size: pagination.value.defaultPageSize,
-      },
-    });
-    let { list } = res.data;
-    // fix: when apisix returns list as {}
-    if (!(list instanceof Array)) {
-      list = [];
-    }
-
-    data.value = list;
-    pagination.value = {
-      ...pagination.value,
-      total: list.length,
+    const resData = await fetchData(undefined, tabPagination.value);
+    tabData.value = resData.list;
+    tabPagination.value = {
+      ...tabPagination.value,
+      total: resData.total,
     };
   } catch (e) {
     console.error(e);
   }
-  dataLoading.value = false;
+  tabDataLoading.value = false;
 };
 
-const deleteIdx = ref<number[]>([]);
+// #endregion Table
 
-onMounted(() => {
-  fetchData();
-});
+// #region Delete
 
-const confirmVisible = ref(false);
+const toDelRowKeys = ref<RowPK[]>([]);
+const delModalVisible = ref(false);
 
-const selectedRowKeys = ref<string[]>([]);
-
-const router = useRouter();
-
-const resetIdx = () => {
-  deleteIdx.value = [];
+const delReset = () => {
+  toDelRowKeys.value = [];
 };
 
-const onConfirmDelete = async () => {
-  // 真实业务请发起请求
-  const ps: AxiosPromise<ApisixAdminRoutesIdDelete200Response>[] = [];
-  deleteIdx.value.forEach((rowIndex) => {
-    const { id } = data.value[rowIndex].value;
-    const p = SSLApi.apisixAdminSslsIdDelete({
-      id: id.toString(), // fix: apisix openapi
-      force: 'false',
-    });
+const delModalOnCancel = () => {
+  delReset();
+};
+
+const delModalOnConfirm = async () => {
+  const ps: Promise<ApisixAdminRoutesIdDelete200Response>[] = [];
+  toDelRowKeys.value.forEach((rowKey) => {
+    const row = tabData.value.find((e) => e.key === rowKey);
+    const p = deleteRow(row);
     ps.push(p);
   });
-  const resArr = await Promise.all(ps);
+  const resDataArr = await Promise.all(ps); // TODO: 报告成功和失败情况
 
-  const successResArr = resArr.filter((res) => {
-    return res.status === 200 && res.data.deleted;
-  });
+  const successResDataArr = resDataArr.filter((d) => d.deleted);
 
-  resetIdx();
-  confirmVisible.value = false;
-  MessagePlugin.success(t('pages.apisixSsl.deleteMessage.success', { num: successResArr.length }));
+  delReset();
+  delModalVisible.value = false;
+  MessagePlugin.success(t('pages.apisixSsl.deleteMessage.success', { num: successResDataArr.length }));
 
-  await fetchData();
+  await tabRefresh();
 };
 
-const onCancel = () => {
-  resetIdx();
+const opOnClickDelete = () => {
+  toDelRowKeys.value = tabSelectedRowKeys.value.slice();
+  delModalVisible.value = true;
 };
 
-const rowKey = 'key';
+const tabRowOnClickDelete = (slotProps: BaseTableCellParams<Row>) => {
+  toDelRowKeys.value = [slotProps.row.key];
+  delModalVisible.value = true;
+};
 
-const rehandleSelectChange = (val: string[]) => {
-  selectedRowKeys.value = val;
-};
-const rehandlePageChange = (curr: unknown, pageInfo: unknown) => {
-  console.log('分页变化', curr, pageInfo);
-};
-const rehandleChange = (changeParams: unknown, triggerAndData: unknown) => {
-  console.log('统一Change', changeParams, triggerAndData);
-};
-const handleClickView = (slotProps: BaseTableCellParams<Item>) => {
-  drawerHeader.value = slotProps.row.value.id.toString(); // fix: apisix openapi
-  drawerBody.value = JSON.stringify(slotProps.row.value, null, 2);
-  drawerVisible.value = true;
-};
-const handleClickEdit = (slotProps: BaseTableCellParams<Item>) => {
-  router.push(`/apisix/ssl/edit?id=${slotProps.row.value.id}`);
-};
-const handleCreate = () => {
+// #endregion Delete
+
+// #region Create
+
+const opClickCreate = () => {
   router.push('/apisix/ssl/edit');
 };
-const handleClickDelete = (slotProps: BaseTableCellParams<Item>) => {
-  deleteIdx.value = [slotProps.rowIndex];
-  confirmVisible.value = true;
+
+// #endregion Create
+
+// #region Edit
+
+const tabRowOnClickEdit = (slotProps: BaseTableCellParams<Row>) => {
+  router.push(`/apisix/ssl/edit?id=${slotProps.row.value.id}`);
 };
 
+// #endregion Edit
+
+// #region Export
+
+const opClickExport = () => {
+  // TODO
+};
+
+// #endregion Export
+
+// #region View
+
+const viewDrawerVisible = ref(false);
+const viewDrawerHeader = ref('');
+const viewDrawerContent = ref('');
+
+const tabRowOnClickView = (slotProps: BaseTableCellParams<Row>) => {
+  viewDrawerHeader.value = slotProps.row.value.id as string;
+  viewDrawerContent.value = JSON.stringify(slotProps.row.value, null, 2);
+  viewDrawerVisible.value = true;
+};
+
+// #endregion View
+
+const settingsStore = useSettingStore();
 const headerAffixedTop = computed(
   () =>
     ({
-      offsetTop: store.isUseTabsRouter ? 48 : 0,
+      offsetTop: settingsStore.isUseTabsRouter ? 48 : 0,
       container: `.${prefix}-layout`,
     }) as any,
 );
-
-const drawerVisible = ref(false);
-const drawerHeader = ref('');
-const drawerBody = ref('');
-
-const onDrawerClickConfirm = () => {
-  MessagePlugin.info('数据保存中...', 1000);
-  const timer = setTimeout(() => {
-    clearTimeout(timer);
-    drawerVisible.value = false;
-    MessagePlugin.info('数据保存成功!');
-  }, 1000);
-};
 </script>
 
 <style lang="less" scoped>

--- a/src/pages/apisix/ssl/index.vue
+++ b/src/pages/apisix/ssl/index.vue
@@ -3,12 +3,12 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="opClickCreate"> {{ t('pages.apisixSsl.create') }} </t-button>
+          <t-button @click="opClickCreate"> {{ t('pages.apisixSsl.operations.create') }} </t-button>
           <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
-            {{ t('pages.apisixSsl.delete') }}
+            {{ t('pages.apisixSsl.operations.delete') }}
           </t-button>
           <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
-            {{ t('pages.apisixSsl.export') }}</t-button
+            {{ t('pages.apisixSsl.operations.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixSsl.selectedCount', { num: tabSelectedRowKeys.length }) }}

--- a/src/pages/apisix/ssl/index.vue
+++ b/src/pages/apisix/ssl/index.vue
@@ -4,10 +4,10 @@
       <t-row justify="space-between">
         <div class="left-operation-container">
           <t-button @click="opClickCreate"> {{ t('pages.apisixSsl.create') }} </t-button>
-          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
             {{ t('pages.apisixSsl.delete') }}
           </t-button>
-          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length > 0" @click="opClickExport">
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
             {{ t('pages.apisixSsl.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">

--- a/src/pages/apisix/ssl/table.ts
+++ b/src/pages/apisix/ssl/table.ts
@@ -1,0 +1,161 @@
+import { Mutable } from '@vueuse/core';
+import { PaginationProps, TableProps } from 'tdesign-vue-next';
+import { ref } from 'vue';
+
+import { SSLApi } from '@/api/apisix/admin';
+import { ApisixAdminSslsGet200ResponseListInner } from '@/api/apisix/admin/typescript-axios';
+import { t } from '@/locales';
+
+// #region Table Columns
+
+/**
+ * 表格行的数据类型
+ */
+export type Row = ApisixAdminSslsGet200ResponseListInner;
+/**
+ * 表格行的主键键名
+ */
+export const ROW_PK: keyof Row = 'key';
+/**
+ * 表格行的主键类型
+ */
+export type RowPK = Row[typeof ROW_PK];
+
+export type Column = TableProps['columns'] & {
+  defaultHidden?: boolean;
+  canModifyHidden?: boolean;
+};
+
+export const COLUMNS: TableProps['columns'] = [
+  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
+  {
+    title: t('pages.apisixSsl.root.key'),
+    colKey: 'key',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixSsl.root.createdIndex'),
+    colKey: 'createdIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixSsl.root.modifiedIndex'),
+    colKey: 'modifiedIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixSsl.value.id'),
+    colKey: 'value.id',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixSsl.value.sni'),
+    colKey: 'value.sni',
+  },
+  {
+    title: t('pages.apisixSsl.value.expireTime'),
+    colKey: 'value.expireTime',
+  },
+  {
+    title: t('pages.apisixSsl.value.create_time'),
+    colKey: 'value.create_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixSsl.value.update_time'),
+    colKey: 'value.update_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixSsl.operation'),
+    align: 'left',
+    fixed: 'right',
+    colKey: 'op',
+    width: 160,
+  },
+];
+
+/**
+ * 固定展示列
+ */
+const FIXED_DISPLAY_COLUMNS: string[] = ['row-select', 'op'];
+
+/**
+ * 展示列
+ */
+export const DISPLAY_COLUMNS = ref<TableProps['displayColumns']>([
+  ...FIXED_DISPLAY_COLUMNS,
+  'value.id',
+  'value.sni',
+  'value.expireTime',
+  'value.update_time',
+]);
+
+export const COLUMN_CONTROLLER = ref<TableProps['columnController']>({
+  // 列配置按钮位置
+  placement: 'top-right',
+  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
+  fields: undefined,
+  // 弹框组件属性透传
+  dialogProps: {
+    preventScrollThrough: true,
+  },
+  // 列配置按钮组件属性透传
+  buttonProps: undefined,
+  // 数据字段分组显示
+  groupColumns: [
+    {
+      label: 'root',
+      value: 'root',
+      columns: ['key', 'createdIndex', 'modifiedIndex'],
+    },
+    {
+      label: 'value',
+      value: 'value',
+      columns: ['value.id', 'value.sni', 'value.expireTime', 'value.create_time', 'value.update_time'],
+    },
+  ],
+});
+
+// #endregion Table Columns
+
+// #region Table Data Action
+
+// 筛选器表单的数据类型
+export type SearchFormData = Mutable<void>; // TODO
+
+export const fetchData = async (searchFormData: SearchFormData, paginationInfo: PaginationProps) => {
+  try {
+    const res = await SSLApi.apisixAdminSslsGet({
+      params: {
+        page: paginationInfo.current,
+        page_size: paginationInfo.pageSize,
+      },
+    });
+
+    // fix: when empty, apisix returns list as {}
+    if (res.data.total === 0 && !(res.data.list instanceof Array)) {
+      res.data.list = [];
+    }
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch data:', error);
+    throw error;
+  }
+};
+
+export const deleteRow = async (row: Row) => {
+  try {
+    const res = await SSLApi.apisixAdminSslsIdDelete({
+      // id: row.value.id,
+      id: row.value.id as string, // fix: apisix openapi is empty interface
+      force: 'false',
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to delete row:', error);
+    throw error;
+  }
+};
+
+// #endregion Table Data Action

--- a/src/pages/apisix/upstream/index.vue
+++ b/src/pages/apisix/upstream/index.vue
@@ -102,7 +102,7 @@ export default {
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
 import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onActivated, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
@@ -114,7 +114,7 @@ import { useSettingStore } from '@/store';
 import type { Row, RowPK } from './table';
 import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-onMounted(() => {
+onActivated(() => {
   tabRefresh();
 });
 

--- a/src/pages/apisix/upstream/index.vue
+++ b/src/pages/apisix/upstream/index.vue
@@ -4,13 +4,13 @@
       <t-row justify="space-between">
         <div class="left-operation-container">
           <t-button @click="opClickCreate"> {{ t('pages.apisixUpstream.create') }} </t-button>
-          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
             {{ t('pages.apisixUpstream.delete') }}
           </t-button>
-          <t-button variant="base" theme="default" :disabled="!tabSelectedRowKeys.length" @click="opClickExport">
+          <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
             {{ t('pages.apisixUpstream.export') }}</t-button
           >
-          <p v-if="!!tabSelectedRowKeys.length" class="selected-count">
+          <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixUpstream.selectedCount', { num: tabSelectedRowKeys.length }) }}
           </p>
         </div>

--- a/src/pages/apisix/upstream/index.vue
+++ b/src/pages/apisix/upstream/index.vue
@@ -3,12 +3,12 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="opClickCreate"> {{ t('pages.apisixUpstream.create') }} </t-button>
+          <t-button @click="opClickCreate"> {{ t('pages.apisixUpstream.operations.create') }} </t-button>
           <t-button theme="danger" :disabled="tabSelectedRowKeys.length <= 0" @click="opOnClickDelete">
-            {{ t('pages.apisixUpstream.delete') }}
+            {{ t('pages.apisixUpstream.operations.delete') }}
           </t-button>
           <t-button variant="base" theme="default" :disabled="tabSelectedRowKeys.length <= 0" @click="opClickExport">
-            {{ t('pages.apisixUpstream.export') }}</t-button
+            {{ t('pages.apisixUpstream.operations.export') }}</t-button
           >
           <p v-if="tabSelectedRowKeys.length > 0" class="selected-count">
             {{ t('pages.apisixUpstream.selectedCount', { num: tabSelectedRowKeys.length }) }}

--- a/src/pages/apisix/upstream/index.vue
+++ b/src/pages/apisix/upstream/index.vue
@@ -3,16 +3,19 @@
     <t-card class="list-card-container" :bordered="false">
       <t-row justify="space-between">
         <div class="left-operation-container">
-          <t-button @click="handleCreate"> {{ t('pages.apisixUpstream.create') }} </t-button>
-          <t-button variant="base" theme="default" :disabled="!selectedRowKeys.length">
+          <t-button @click="opClickCreate"> {{ t('pages.apisixUpstream.create') }} </t-button>
+          <t-button theme="danger" :disabled="tabSelectedRowKeys.length > 0" @click="opOnClickDelete">
+            {{ t('pages.apisixUpstream.delete') }}
+          </t-button>
+          <t-button variant="base" theme="default" :disabled="!tabSelectedRowKeys.length" @click="opClickExport">
             {{ t('pages.apisixUpstream.export') }}</t-button
           >
-          <p v-if="!!selectedRowKeys.length" class="selected-count">
-            {{ t('pages.apisixUpstream.selectedCount', { num: selectedRowKeys.length }) }}
+          <p v-if="!!tabSelectedRowKeys.length" class="selected-count">
+            {{ t('pages.apisixUpstream.selectedCount', { num: tabSelectedRowKeys.length }) }}
           </p>
         </div>
         <div class="search-input">
-          <t-input v-model="searchValue" :placeholder="t('pages.apisixUpstream.placeholder')" clearable>
+          <t-input v-model="tabSearchValue" :placeholder="t('pages.apisixUpstream.placeholder')" clearable>
             <template #suffix-icon>
               <search-icon size="16px" />
             </template>
@@ -20,41 +23,39 @@
         </div>
       </t-row>
       <t-table
-        v-model:displayColumns="displayColumns"
-        :data="data"
+        v-model:display-columns="DISPLAY_COLUMNS"
+        :data="tabData"
         :columns="COLUMNS"
-        :column-controller="columnControllerConfig"
-        :row-key="rowKey"
+        :column-controller="COLUMN_CONTROLLER"
+        :row-key="ROW_PK"
         vertical-align="top"
         :hover="true"
-        :pagination="pagination"
-        :selected-row-keys="selectedRowKeys"
-        :loading="dataLoading"
+        :pagination="tabPagination"
+        :selected-row-keys="tabSelectedRowKeys"
+        :loading="tabDataLoading"
         :header-affixed-top="headerAffixedTop"
         table-layout="auto"
-        @page-change="rehandlePageChange"
-        @change="rehandleChange"
-        @select-change="(value: string[]) => rehandleSelectChange(value)"
+        @select-change="tabSelectChange"
       >
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.create_time="{ row }">
+        <template #value.create_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.create_time).format('L LT') }}
         </template>
 
         <!-- eslint-disable-next-line vue/valid-v-slot -->
-        <template #value.update_time="{ row }">
+        <template #value.update_time="{ row }: BaseTableCellParams<Row>">
           {{ dayjs.unix(row.value.update_time).format('L LT') }}
         </template>
 
-        <template #op="slotProps: BaseTableCellParams<Item>">
+        <template #op="slotProps: BaseTableCellParams<Row>">
           <t-space>
-            <t-link theme="primary" @click="handleClickView(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickView(slotProps)">
               {{ t('pages.apisixUpstream.operations.view') }}</t-link
             >
-            <t-link theme="primary" @click="handleClickEdit(slotProps)">
+            <t-link theme="primary" @click="tabRowOnClickEdit(slotProps)">
               {{ t('pages.apisixUpstream.operations.edit') }}</t-link
             >
-            <t-link theme="danger" @click="handleClickDelete(slotProps)">
+            <t-link theme="danger" @click="tabRowOnClickDelete(slotProps)">
               {{ t('pages.apisixUpstream.operations.delete') }}</t-link
             >
           </t-space>
@@ -63,30 +64,30 @@
     </t-card>
 
     <t-dialog
-      v-model:visible="confirmVisible"
+      v-model:visible="delModalVisible"
       :header="t('pages.apisixUpstream.deleteConfirm.header')"
-      :on-cancel="onCancel"
-      @confirm="onConfirmDelete"
+      :on-cancel="delModalOnCancel"
+      @confirm="delModalOnConfirm"
     >
-      <p v-if="deleteIdx.length === 1">
+      <p v-if="toDelRowKeys.length === 1">
         {{
           t('pages.apisixUpstream.deleteConfirm.deleteOne', {
-            name: data[deleteIdx[0]]?.value?.id,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
           })
         }}
       </p>
-      <p v-if="deleteIdx.length > 1">
+      <p v-if="toDelRowKeys.length > 1">
         {{
           t('pages.apisixUpstream.deleteConfirm.deleteMulti', {
-            name: data[deleteIdx[0]]?.value?.id,
-            num: deleteIdx.length,
+            name: tabData.find((e) => e.key === toDelRowKeys[0])?.value?.id,
+            num: toDelRowKeys.length,
           })
         }}
       </p>
     </t-dialog>
 
-    <t-drawer v-model:visible="drawerVisible" :header="drawerHeader" :on-confirm="onDrawerClickConfirm" size="medium">
-      <code-editor v-model:value="drawerBody" language="json" />
+    <t-drawer v-model:visible="viewDrawerVisible" :header="viewDrawerHeader" size="medium">
+      <code-editor v-model:value="viewDrawerContent" language="json" />
     </t-drawer>
   </div>
 </template>
@@ -98,228 +99,149 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { AxiosPromise } from 'axios';
 import dayjs from 'dayjs';
 import { SearchIcon } from 'tdesign-icons-vue-next';
-import { BaseTableCellParams, MessagePlugin, PrimaryTableCol, TableProps, TableRowData } from 'tdesign-vue-next';
+import { BaseTableCellParams, MessagePlugin, TableProps } from 'tdesign-vue-next';
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { UpstreamApi } from '@/api/apisix/admin';
-import {
-  ApisixAdminRoutesIdDelete200Response,
-  ApisixAdminUpstreamsGet200ResponseListInner as Item,
-} from '@/api/apisix/admin/typescript-axios';
+import { ApisixAdminRoutesIdDelete200Response } from '@/api/apisix/admin/typescript-axios';
 import CodeEditor from '@/components/code-editor/index.vue';
 import { prefix } from '@/config/global';
 import { t } from '@/locales';
 import { useSettingStore } from '@/store';
 
-const store = useSettingStore();
+import type { Row, RowPK } from './table';
+import { COLUMN_CONTROLLER, COLUMNS, deleteRow, DISPLAY_COLUMNS, fetchData, ROW_PK } from './table';
 
-const COLUMNS: PrimaryTableCol<TableRowData>[] = [
-  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
-  {
-    title: t('pages.apisixUpstream.root.key'),
-    colKey: 'key',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixUpstream.root.createdIndex'),
-    colKey: 'createdIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixUpstream.root.modifiedIndex'),
-    colKey: 'modifiedIndex',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixUpstream.value.id'),
-    colKey: 'value.id',
-    fixed: 'left',
-  },
-  {
-    title: t('pages.apisixUpstream.value.name'),
-    colKey: 'value.name',
-  },
-  {
-    title: t('pages.apisixUpstream.value.desc'),
-    colKey: 'value.desc',
-  },
-  {
-    title: t('pages.apisixUpstream.value.create_time'),
-    colKey: 'value.create_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixUpstream.value.update_time'),
-    colKey: 'value.update_time',
-    width: 240,
-  },
-  {
-    title: t('pages.apisixUpstream.operation'),
-    align: 'left',
-    fixed: 'right',
-    colKey: 'op',
-    width: 160,
-  },
-];
-const staticColumn: string[] = ['row-select', 'op'];
-const displayColumns = ref<TableProps['displayColumns']>(staticColumn.concat(['value.id', 'value.name', 'value.desc']));
-const columnControllerConfig = computed<TableProps['columnController']>(() => ({
-  // 列配置按钮位置
-  placement: 'top-right',
-  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
-  fields: undefined,
-  // 弹框组件属性透传
-  dialogProps: {
-    preventScrollThrough: true,
-  },
-  // 列配置按钮组件属性透传
-  buttonProps: undefined,
-  // 数据字段分组显示
-  groupColumns: [
-    {
-      label: 'root',
-      value: 'root',
-      columns: ['key', 'createdIndex', 'modifiedIndex'],
-    },
-    {
-      label: 'value',
-      value: 'value',
-      columns: ['value.id', 'value.name', 'value.desc', 'value.create_time', 'value.update_time'],
-    },
-  ],
-}));
+onMounted(() => {
+  tabRefresh();
+});
 
-const data = ref<Item[]>([]);
-const pagination = ref({
+const router = useRouter();
+
+// #region Table
+
+const tabPagination = ref({
   defaultPageSize: 20,
   total: 100,
   defaultCurrent: 1,
 });
+const tabSearchValue = ref('');
+const tabData = ref<Row[]>([]);
+const tabDataLoading = ref(false);
+const tabSelectedRowKeys = ref<RowPK[]>([]);
 
-const searchValue = ref('');
+const tabSelectChange: TableProps['onSelectChange'] = (selectedRowKey, options) => {
+  tabSelectedRowKeys.value = selectedRowKey.slice() as RowPK[];
+};
 
-const dataLoading = ref(false);
-const fetchData = async () => {
-  dataLoading.value = true;
+const tabRefresh = async () => {
+  tabDataLoading.value = true;
   try {
-    const res = await UpstreamApi.apisixAdminUpstreamsGet({
-      params: {
-        page: pagination.value.defaultCurrent,
-        page_size: pagination.value.defaultPageSize,
-      },
-    });
-    let { list } = res.data;
-    // fix: when apisix returns list as {}
-    if (!(list instanceof Array)) {
-      list = [];
-    }
-
-    data.value = list;
-    pagination.value = {
-      ...pagination.value,
-      total: list.length,
+    const resData = await fetchData(undefined, tabPagination.value);
+    tabData.value = resData.list;
+    tabPagination.value = {
+      ...tabPagination.value,
+      total: resData.total,
     };
   } catch (e) {
     console.error(e);
   }
-  dataLoading.value = false;
+  tabDataLoading.value = false;
 };
 
-const deleteIdx = ref<number[]>([]);
+// #endregion Table
 
-onMounted(() => {
-  fetchData();
-});
+// #region Delete
 
-const confirmVisible = ref(false);
+const toDelRowKeys = ref<RowPK[]>([]);
+const delModalVisible = ref(false);
 
-const selectedRowKeys = ref<string[]>([]);
-
-const router = useRouter();
-
-const resetIdx = () => {
-  deleteIdx.value = [];
+const delReset = () => {
+  toDelRowKeys.value = [];
 };
 
-const onConfirmDelete = async () => {
-  // 真实业务请发起请求
-  const ps: AxiosPromise<ApisixAdminRoutesIdDelete200Response>[] = [];
-  deleteIdx.value.forEach((rowIndex) => {
-    const { id } = data.value[rowIndex].value;
-    const p = UpstreamApi.apisixAdminUpstreamsIdDelete({
-      id: id.toString(), // fix: apisix openapi
-      force: 'false',
-    });
+const delModalOnCancel = () => {
+  delReset();
+};
+
+const delModalOnConfirm = async () => {
+  const ps: Promise<ApisixAdminRoutesIdDelete200Response>[] = [];
+  toDelRowKeys.value.forEach((rowKey) => {
+    const row = tabData.value.find((e) => e.key === rowKey);
+    const p = deleteRow(row);
     ps.push(p);
   });
-  const resArr = await Promise.all(ps);
+  const resDataArr = await Promise.all(ps); // TODO: 报告成功和失败情况
 
-  const successResArr = resArr.filter((res) => {
-    return res.status === 200 && res.data.deleted;
-  });
+  const successResDataArr = resDataArr.filter((d) => d.deleted);
 
-  resetIdx();
-  confirmVisible.value = false;
-  MessagePlugin.success(t('pages.apisixUpstream.deleteMessage.success', { num: successResArr.length }));
+  delReset();
+  delModalVisible.value = false;
+  MessagePlugin.success(t('pages.apisixUpstream.deleteMessage.success', { num: successResDataArr.length }));
 
-  await fetchData();
+  await tabRefresh();
 };
 
-const onCancel = () => {
-  resetIdx();
+const opOnClickDelete = () => {
+  toDelRowKeys.value = tabSelectedRowKeys.value.slice();
+  delModalVisible.value = true;
 };
 
-const rowKey = 'key';
+const tabRowOnClickDelete = (slotProps: BaseTableCellParams<Row>) => {
+  toDelRowKeys.value = [slotProps.row.key];
+  delModalVisible.value = true;
+};
 
-const rehandleSelectChange = (val: string[]) => {
-  selectedRowKeys.value = val;
-};
-const rehandlePageChange = (curr: unknown, pageInfo: unknown) => {
-  console.log('分页变化', curr, pageInfo);
-};
-const rehandleChange = (changeParams: unknown, triggerAndData: unknown) => {
-  console.log('统一Change', changeParams, triggerAndData);
-};
-const handleClickView = (slotProps: BaseTableCellParams<Item>) => {
-  drawerHeader.value = slotProps.row.value.id.toString(); // fix: apisix openapi
-  drawerBody.value = JSON.stringify(slotProps.row.value, null, 2);
-  drawerVisible.value = true;
-};
-const handleClickEdit = (slotProps: BaseTableCellParams<Item>) => {
-  router.push(`/apisix/upstream/edit?id=${slotProps.row.value.id}`);
-};
-const handleCreate = () => {
+// #endregion Delete
+
+// #region Create
+
+const opClickCreate = () => {
   router.push('/apisix/upstream/edit');
 };
-const handleClickDelete = (slotProps: BaseTableCellParams<Item>) => {
-  deleteIdx.value = [slotProps.rowIndex];
-  confirmVisible.value = true;
+
+// #endregion Create
+
+// #region Edit
+
+const tabRowOnClickEdit = (slotProps: BaseTableCellParams<Row>) => {
+  router.push(`/apisix/upstream/edit?id=${slotProps.row.value.id}`);
 };
 
+// #endregion Edit
+
+// #region Export
+
+const opClickExport = () => {
+  // TODO
+};
+
+// #endregion Export
+
+// #region View
+
+const viewDrawerVisible = ref(false);
+const viewDrawerHeader = ref('');
+const viewDrawerContent = ref('');
+
+const tabRowOnClickView = (slotProps: BaseTableCellParams<Row>) => {
+  viewDrawerHeader.value = slotProps.row.value.id as string;
+  viewDrawerContent.value = JSON.stringify(slotProps.row.value, null, 2);
+  viewDrawerVisible.value = true;
+};
+
+// #endregion View
+
+const settingsStore = useSettingStore();
 const headerAffixedTop = computed(
   () =>
     ({
-      offsetTop: store.isUseTabsRouter ? 48 : 0,
+      offsetTop: settingsStore.isUseTabsRouter ? 48 : 0,
       container: `.${prefix}-layout`,
     }) as any,
 );
-
-const drawerVisible = ref(false);
-const drawerHeader = ref('');
-const drawerBody = ref('');
-
-const onDrawerClickConfirm = () => {
-  MessagePlugin.info('数据保存中...', 1000);
-  const timer = setTimeout(() => {
-    clearTimeout(timer);
-    drawerVisible.value = false;
-    MessagePlugin.info('数据保存成功!');
-  }, 1000);
-};
 </script>
 
 <style lang="less" scoped>

--- a/src/pages/apisix/upstream/table.ts
+++ b/src/pages/apisix/upstream/table.ts
@@ -1,0 +1,161 @@
+import { Mutable } from '@vueuse/core';
+import { PaginationProps, TableProps } from 'tdesign-vue-next';
+import { ref } from 'vue';
+
+import { UpstreamApi } from '@/api/apisix/admin';
+// import { ApisixAdminUpstreamsGet200ResponseListInner } from '@/api/apisix/admin/typescript-axios';
+import { t } from '@/locales';
+
+// #region Table Columns
+
+/**
+ * 表格行的数据类型
+ */
+// export type Row = ApisixAdminUpstreamsGet200ResponseListInner;
+export type Row = Record<string, any>; // fix: apisix openapi is string
+/**
+ * 表格行的主键键名
+ */
+export const ROW_PK: keyof Row = 'key';
+/**
+ * 表格行的主键类型
+ */
+export type RowPK = Row[typeof ROW_PK];
+
+export type Column = TableProps['columns'] & {
+  defaultHidden?: boolean;
+  canModifyHidden?: boolean;
+};
+
+export const COLUMNS: TableProps['columns'] = [
+  { colKey: 'row-select', type: 'multiple', width: 64, fixed: 'left' },
+  {
+    title: t('pages.apisixUpstream.root.key'),
+    colKey: 'key',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixUpstream.root.createdIndex'),
+    colKey: 'createdIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixUpstream.root.modifiedIndex'),
+    colKey: 'modifiedIndex',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixUpstream.value.id'),
+    colKey: 'value.id',
+    fixed: 'left',
+  },
+  {
+    title: t('pages.apisixUpstream.value.name'),
+    colKey: 'value.name',
+  },
+  {
+    title: t('pages.apisixUpstream.value.desc'),
+    colKey: 'value.desc',
+  },
+  {
+    title: t('pages.apisixUpstream.value.create_time'),
+    colKey: 'value.create_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixUpstream.value.update_time'),
+    colKey: 'value.update_time',
+    width: 240,
+  },
+  {
+    title: t('pages.apisixUpstream.operation'),
+    align: 'left',
+    fixed: 'right',
+    colKey: 'op',
+    width: 160,
+  },
+];
+
+/**
+ * 固定展示列
+ */
+const FIXED_DISPLAY_COLUMNS: string[] = ['row-select', 'op'];
+
+/**
+ * 展示列
+ */
+export const DISPLAY_COLUMNS = ref<TableProps['displayColumns']>([
+  ...FIXED_DISPLAY_COLUMNS,
+  'value.id',
+  'value.name',
+  'value.desc',
+]);
+
+export const COLUMN_CONTROLLER = ref<TableProps['columnController']>({
+  // 列配置按钮位置
+  placement: 'top-right',
+  // 用于设置允许用户对哪些列进行显示或隐藏的控制，默认为全部字段
+  fields: undefined,
+  // 弹框组件属性透传
+  dialogProps: {
+    preventScrollThrough: true,
+  },
+  // 列配置按钮组件属性透传
+  buttonProps: undefined,
+  // 数据字段分组显示
+  groupColumns: [
+    {
+      label: 'root',
+      value: 'root',
+      columns: ['key', 'createdIndex', 'modifiedIndex'],
+    },
+    {
+      label: 'value',
+      value: 'value',
+      columns: ['value.id', 'value.name', 'value.desc', 'value.create_time', 'value.update_time'],
+    },
+  ],
+});
+
+// #endregion Table Columns
+
+// #region Table Data Action
+
+// 筛选器表单的数据类型
+export type SearchFormData = Mutable<void>; // TODO
+
+export const fetchData = async (searchFormData: SearchFormData, paginationInfo: PaginationProps) => {
+  try {
+    const res = await UpstreamApi.apisixAdminUpstreamsGet({
+      params: {
+        page: paginationInfo.current,
+        page_size: paginationInfo.pageSize,
+      },
+    });
+
+    // fix: when empty, apisix returns list as {}
+    if (res.data.total === 0 && !(res.data.list instanceof Array)) {
+      res.data.list = [];
+    }
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch data:', error);
+    throw error;
+  }
+};
+
+export const deleteRow = async (row: Row) => {
+  try {
+    const res = await UpstreamApi.apisixAdminUpstreamsIdDelete({
+      // id: row.value.id,
+      id: row.value.id as string, // fix: apisix openapi is empty interface
+      force: 'false',
+    });
+    return res.data;
+  } catch (error) {
+    console.error('Failed to delete row:', error);
+    throw error;
+  }
+};
+
+// #endregion Table Data Action


### PR DESCRIPTION
chore: mv columns define & data action to table.ts
chore: add region comment
change: resData.total instanceof list.length for pagination
change: rm route create_time, openapi is not defined this
fix: reactivated pages is not refresh tab data
feat: add batch delete
change: unified viewing behavior without modifying data
wip: SearchParams
wip: Export
wip: enhance columns define

----

使用单独的table.ts定义数据格式、列展示、请求/转换数据

WIP：将在之后的PR实现

1、支持筛选参数
2、表格列定义目前由于组件原因，是拆分成多个对象的，后续合并成一个对象。更方便定义和修改
3、现在表格页面代码块用region标注了，后续可视情况对重复的代码复用